### PR TITLE
Complete note-taking PRDs 047–050: link evidence, entity pages, relationship suggestions, quest promotion, Nuclino link stats

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1" />
-    <title>Quest Keeper - Gaming Coordination App</title>
+    <title>Helm - Gaming Coordination App</title>
     <meta name="description" content="Coordinate your tabletop gaming sessions with ease. Schedule games, manage notes, roll dice, and keep your party organized." />
     <link rel="icon" type="image/png" href="/favicon.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/client/src/components/ai-paywall-stub-dialog.tsx
+++ b/client/src/components/ai-paywall-stub-dialog.tsx
@@ -64,7 +64,9 @@ export function AIPaywallStubDialog({
 
   const handleEnableAI = () => {
     onOpenChange(false);
-    setLocation(`/teams/${teamId}/settings`);
+    // Gap F56 (PRD-031 FR-3): Settings is registered at /settings; the old
+    // /teams/:id/settings path matched no route and landed on the 404 page.
+    setLocation("/settings");
   };
 
   const handleContinueWithoutAI = () => {

--- a/client/src/components/enrichment-review-dialog.tsx
+++ b/client/src/components/enrichment-review-dialog.tsx
@@ -140,8 +140,11 @@ export function EnrichmentReviewDialog({
       return response.json() as Promise<EnrichmentRunData>;
     },
     enabled: open && !!enrichmentRunId,
-    refetchInterval: (data) =>
-      data?.status === "running" || data?.status === "pending" ? 2000 : false,
+    // TanStack Query v5 passes the Query object (not data) to refetchInterval
+    refetchInterval: (query) => {
+      const status = query.state.data?.status;
+      return status === "running" || status === "pending" ? 2000 : false;
+    },
   });
 
   // Approve classification mutation

--- a/client/src/components/import-management.test.tsx
+++ b/client/src/components/import-management.test.tsx
@@ -88,9 +88,19 @@ const completedEnrichment = {
   relationships: [],
 };
 
+// P2-4 F49: fixture for GET /api/teams/:teamId/imports/:importId (View details)
+const importDetailsFixture = {
+  ...completedImport,
+  notes: [
+    { id: "note-1", title: "Gandalf the Grey", noteType: "npc", wasUpdated: false },
+    { id: "note-2", title: "Session 12 Recap", noteType: "session_log", wasUpdated: true },
+  ],
+};
+
 let importsFixture: unknown[];
 let enrichPostResponse: { body: unknown; status: number };
 let enrichmentFixture: unknown;
+let importDetailsResponse: { body: unknown; status: number };
 
 function jsonResponse(body: unknown, status = 200) {
   return {
@@ -109,6 +119,10 @@ const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => 
   }
   if (/\/imports\/[^/]+\/enrich$/.test(url) && method === "POST") {
     return jsonResponse(enrichPostResponse.body, enrichPostResponse.status);
+  }
+  // P2-4 F49: import run details for the View Details dialog
+  if (/\/imports\/[^/]+$/.test(url) && method === "GET") {
+    return jsonResponse(importDetailsResponse.body, importDetailsResponse.status);
   }
   if (url.includes("/enrichments/") && method === "GET") {
     return jsonResponse(enrichmentFixture);
@@ -143,6 +157,7 @@ beforeEach(() => {
     status: 400,
   };
   enrichmentFixture = completedEnrichment;
+  importDetailsResponse = { body: importDetailsFixture, status: 200 };
 });
 
 describe("ImportManagement AI suggestions button (P0-4)", () => {
@@ -260,5 +275,90 @@ describe("ImportManagement AI suggestions button (P0-4)", () => {
       );
     });
     expect(screen.queryByText("Review AI Suggestions")).not.toBeInTheDocument();
+  });
+});
+
+describe("ImportManagement view details dialog (P2-4 F49)", () => {
+  it("renders a View import details action on every import row", async () => {
+    importsFixture = [completedImport, failedImport];
+    renderImportManagement();
+
+    const buttons = await screen.findAllByRole("button", {
+      name: /view import details/i,
+    });
+    expect(buttons).toHaveLength(2);
+  });
+
+  it("opens the details dialog listing the run's notes with type and created/updated badges", async () => {
+    renderImportManagement();
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: /view import details/i })
+    );
+
+    // Dialog opens and fetches the run details
+    expect(await screen.findByText("Import Details")).toBeInTheDocument();
+    expect(await screen.findByText("Gandalf the Grey")).toBeInTheDocument();
+    expect(screen.getByText("Session 12 Recap")).toBeInTheDocument();
+
+    // Count summary from the run's notes and stats
+    expect(
+      screen.getByText(/2 notes in this import \(3 created, 0 updated\)/)
+    ).toBeInTheDocument();
+
+    // noteType badges
+    expect(screen.getByText("npc")).toBeInTheDocument();
+    expect(screen.getByText("session_log")).toBeInTheDocument();
+
+    // created/updated indicator (data distinguishes via wasUpdated)
+    expect(screen.getByText("created")).toBeInTheDocument();
+    expect(screen.getByText("updated")).toBeInTheDocument();
+
+    // Details were fetched from the PRD-015A endpoint
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/teams/team-1/imports/imp-1",
+      expect.objectContaining({ credentials: "include" })
+    );
+  });
+
+  it("shows a loading state while details are being fetched", async () => {
+    // Defer the details response so the loading state is observable
+    let resolveDetails: (value: Response) => void;
+    const deferred = new Promise<Response>((resolve) => {
+      resolveDetails = resolve;
+    });
+    fetchMock.mockImplementationOnce(async (input: RequestInfo | URL) => {
+      // First call is the imports list
+      expect(String(input)).toBe("/api/teams/team-1/imports");
+      return jsonResponse(importsFixture);
+    });
+    fetchMock.mockImplementationOnce(() => deferred);
+
+    renderImportManagement();
+    fireEvent.click(
+      await screen.findByRole("button", { name: /view import details/i })
+    );
+
+    expect(await screen.findByText(/loading import details/i)).toBeInTheDocument();
+
+    resolveDetails!(jsonResponse(importDetailsFixture));
+    expect(await screen.findByText("Gandalf the Grey")).toBeInTheDocument();
+    expect(screen.queryByText(/loading import details/i)).not.toBeInTheDocument();
+  });
+
+  it("closes the dialog when dismissed", async () => {
+    renderImportManagement();
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: /view import details/i })
+    );
+    await screen.findByText("Gandalf the Grey");
+
+    // Radix dialog exposes a Close button
+    fireEvent.click(screen.getByRole("button", { name: /close/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByText("Import Details")).not.toBeInTheDocument();
+    });
   });
 });

--- a/client/src/components/import-management.test.tsx
+++ b/client/src/components/import-management.test.tsx
@@ -1,0 +1,264 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * P0-4 (F55): Import Management mounts the EnrichmentReviewDialog so users
+ * can review pending AI enrichment suggestions. The "AI suggestions" action
+ * uses POST /enrich for discovery: a 400 response returns the existing run's
+ * id (review path); an OK response means a new enrichment run was started.
+ */
+import "@testing-library/jest-dom";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ImportManagement } from "./import-management";
+
+const mockInvalidateQueries = vi.fn();
+vi.mock("@/lib/queryClient", () => ({
+  queryClient: {
+    invalidateQueries: (...args: unknown[]) => mockInvalidateQueries(...args),
+  },
+  apiRequest: vi.fn(),
+}));
+
+const mockToast = vi.fn();
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: (...args: unknown[]) => mockToast(...args) }),
+}));
+
+// jsdom polyfills for Radix primitives used by the dialog
+class ResizeObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+(globalThis as any).ResizeObserver = ResizeObserverMock;
+Element.prototype.scrollIntoView = vi.fn();
+(Element.prototype as any).hasPointerCapture = vi.fn();
+(Element.prototype as any).setPointerCapture = vi.fn();
+(Element.prototype as any).releasePointerCapture = vi.fn();
+
+const completedImport = {
+  id: "imp-1",
+  teamId: "team-1",
+  sourceSystem: "NUCLINO",
+  createdByUserId: "user-1",
+  status: "completed",
+  options: { importEmptyPages: false, defaultVisibility: "team" },
+  stats: {
+    totalPagesDetected: 3,
+    notesCreated: 3,
+    notesUpdated: 0,
+    notesSkipped: 0,
+    emptyPagesImported: 0,
+    linksResolved: 1,
+    warningsCount: 0,
+  },
+  createdAt: "2026-06-01T12:00:00.000Z",
+  importerName: "Ronnie G",
+};
+
+const failedImport = {
+  ...completedImport,
+  id: "imp-2",
+  status: "failed",
+};
+
+const completedEnrichment = {
+  id: "enr-1",
+  status: "completed",
+  totals: {
+    notesProcessed: 3,
+    classificationsCreated: 1,
+    relationshipsFound: 0,
+    highConfidenceCount: 1,
+    lowConfidenceCount: 0,
+    userReviewRequired: 0,
+  },
+  classifications: [
+    {
+      id: "cls-1",
+      noteId: "note-1",
+      noteTitle: "Kettle",
+      inferredType: "Person",
+      confidence: 0.9,
+      explanation: "Named character with dialogue",
+      status: "pending",
+    },
+  ],
+  relationships: [],
+};
+
+let importsFixture: unknown[];
+let enrichPostResponse: { body: unknown; status: number };
+let enrichmentFixture: unknown;
+
+function jsonResponse(body: unknown, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as Response;
+}
+
+const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+  const url = String(input);
+  const method = init?.method || "GET";
+
+  if (url === "/api/teams/team-1/imports" && method === "GET") {
+    return jsonResponse(importsFixture);
+  }
+  if (/\/imports\/[^/]+\/enrich$/.test(url) && method === "POST") {
+    return jsonResponse(enrichPostResponse.body, enrichPostResponse.status);
+  }
+  if (url.includes("/enrichments/") && method === "GET") {
+    return jsonResponse(enrichmentFixture);
+  }
+  throw new Error(`Unexpected fetch: ${method} ${url}`);
+});
+(globalThis as any).fetch = fetchMock;
+
+function renderImportManagement() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return render(
+    <QueryClientProvider client={client}>
+      <ImportManagement teamId="team-1" isDM={true} currentUserId="user-1" />
+    </QueryClientProvider>
+  );
+}
+
+beforeEach(() => {
+  mockInvalidateQueries.mockReset();
+  mockToast.mockReset();
+  fetchMock.mockClear();
+  importsFixture = [completedImport];
+  enrichPostResponse = {
+    body: {
+      message: "Enrichment already exists for this import",
+      enrichmentRunId: "enr-1",
+      status: "completed",
+    },
+    status: 400,
+  };
+  enrichmentFixture = completedEnrichment;
+});
+
+describe("ImportManagement AI suggestions button (P0-4)", () => {
+  it("renders the Review AI suggestions button on completed import rows", async () => {
+    renderImportManagement();
+
+    expect(
+      await screen.findByRole("button", { name: /review ai suggestions/i })
+    ).toBeInTheDocument();
+  });
+
+  it("does not render the button when no reviewable import exists (failed import)", async () => {
+    importsFixture = [failedImport];
+    renderImportManagement();
+
+    // Row rendered but no AI suggestions action
+    expect(await screen.findByText("NUCLINO")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /review ai suggestions/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("opens the EnrichmentReviewDialog for an existing enrichment run", async () => {
+    renderImportManagement();
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: /review ai suggestions/i })
+    );
+
+    // Dialog opens on the review view with the fixture classification
+    expect(await screen.findByText("Review AI Suggestions")).toBeInTheDocument();
+    expect(screen.getByText("Kettle")).toBeInTheDocument();
+    expect(screen.getByText(/Classifications \(1\)/)).toBeInTheDocument();
+
+    // Discovery used POST /enrich and then fetched the existing run
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/teams/team-1/imports/imp-1/enrich",
+      expect.objectContaining({ method: "POST" })
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/teams/team-1/enrichments/enr-1",
+      expect.objectContaining({ credentials: "include" })
+    );
+
+    // No "started" toast on the review path
+    expect(mockToast).not.toHaveBeenCalled();
+  });
+
+  it("starts a new enrichment and shows progress when none exists yet", async () => {
+    enrichPostResponse = {
+      body: { enrichmentRunId: "enr-2", status: "pending" },
+      status: 200,
+    };
+    enrichmentFixture = {
+      id: "enr-2",
+      status: "pending",
+      totals: null,
+      classifications: [],
+      relationships: [],
+    };
+    renderImportManagement();
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: /review ai suggestions/i })
+    );
+
+    expect(
+      await screen.findByText("AI Enhancement in Progress")
+    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "AI enrichment started" })
+      );
+    });
+  });
+
+  it("invalidates needs-review and notes queries when the dialog closes", async () => {
+    renderImportManagement();
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: /review ai suggestions/i })
+    );
+    await screen.findByText("Review AI Suggestions");
+
+    fireEvent.click(screen.getByRole("button", { name: /done reviewing/i }));
+
+    await waitFor(() => {
+      expect(mockInvalidateQueries).toHaveBeenCalledWith({
+        queryKey: ["/api/teams", "team-1", "notes", "needs-review"],
+      });
+      expect(mockInvalidateQueries).toHaveBeenCalledWith({
+        queryKey: ["/api/teams", "team-1", "notes"],
+      });
+    });
+    expect(screen.queryByText("Review AI Suggestions")).not.toBeInTheDocument();
+  });
+
+  it("shows an error toast and no dialog when AI is unavailable", async () => {
+    enrichPostResponse = {
+      body: { message: "AI features require a subscription" },
+      status: 403,
+    };
+    renderImportManagement();
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: /review ai suggestions/i })
+    );
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variant: "destructive",
+          description: "AI features require a subscription",
+        })
+      );
+    });
+    expect(screen.queryByText("Review AI Suggestions")).not.toBeInTheDocument();
+  });
+});

--- a/client/src/components/import-management.tsx
+++ b/client/src/components/import-management.tsx
@@ -18,10 +18,13 @@ import {
   Users,
   FileText,
   AlertCircle,
+  Sparkles,
+  Loader2,
 } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { queryClient } from "@/lib/queryClient";
 import { format } from "date-fns";
+import { EnrichmentReviewDialog } from "@/components/enrichment-review-dialog";
 
 interface ImportRunOptions {
   importEmptyPages: boolean;
@@ -59,6 +62,9 @@ interface ImportManagementProps {
 export function ImportManagement({ teamId, isDM, currentUserId }: ImportManagementProps) {
   const { toast } = useToast();
   const [deleteTarget, setDeleteTarget] = useState<ImportRun | null>(null);
+  // PRD-016 / P0-4: enrichment run currently open in the review dialog
+  const [reviewEnrichmentRunId, setReviewEnrichmentRunId] = useState<string | null>(null);
+  const [enrichTargetId, setEnrichTargetId] = useState<string | null>(null);
 
   const { data: imports, isLoading } = useQuery<ImportRun[]>({
     queryKey: ["/api/teams", teamId, "imports"],
@@ -100,6 +106,58 @@ export function ImportManagement({ teamId, isDM, currentUserId }: ImportManageme
       });
     },
   });
+
+  // PRD-016 / P0-4: Open (or start) the AI enrichment review for an import.
+  // There is no read endpoint exposing an import's enrichment run, so we use
+  // POST /enrich: a 400 response means a run already exists and returns its id
+  // (no side effect); an OK response means a new enrichment was started.
+  const enrichMutation = useMutation({
+    mutationFn: async (importId: string) => {
+      const response = await fetch(`/api/teams/${teamId}/imports/${importId}/enrich`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+        credentials: "include",
+      });
+      const data = await response.json();
+      if (response.ok && data.enrichmentRunId) {
+        return { enrichmentRunId: data.enrichmentRunId as string, started: true };
+      }
+      if (response.status === 400 && data.enrichmentRunId) {
+        // Enrichment already exists for this import - review it
+        return { enrichmentRunId: data.enrichmentRunId as string, started: false };
+      }
+      throw new Error(data.message || "Failed to load AI suggestions");
+    },
+    onSuccess: ({ enrichmentRunId, started }) => {
+      if (started) {
+        toast({
+          title: "AI enrichment started",
+          description: "Notes are being analyzed. Suggestions will appear when ready.",
+        });
+      }
+      setReviewEnrichmentRunId(enrichmentRunId);
+    },
+    onError: (error: Error) => {
+      toast({
+        title: "AI suggestions unavailable",
+        description: error.message,
+        variant: "destructive",
+      });
+    },
+    onSettled: () => {
+      setEnrichTargetId(null);
+    },
+  });
+
+  const handleReviewDialogChange = (open: boolean) => {
+    if (!open) {
+      setReviewEnrichmentRunId(null);
+      // Approvals in the dialog change note types and clear needs-review items
+      queryClient.invalidateQueries({ queryKey: ["/api/teams", teamId, "notes", "needs-review"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/teams", teamId, "notes"] });
+    }
+  };
 
   const canDelete = (importRun: ImportRun) => {
     return isDM || importRun.createdByUserId === currentUserId;
@@ -159,18 +217,51 @@ export function ImportManagement({ teamId, isDM, currentUserId }: ImportManageme
             )}
           </div>
 
-          {canDelete(importRun) && (
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={() => setDeleteTarget(importRun)}
-              className="text-destructive hover:text-destructive"
-            >
-              <Trash2 className="h-4 w-4" />
-            </Button>
-          )}
+          <div className="flex items-center gap-1 shrink-0 ml-2">
+            {importRun.status === "completed" && (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="gap-1 text-primary hover:text-primary"
+                onClick={() => {
+                  setEnrichTargetId(importRun.id);
+                  enrichMutation.mutate(importRun.id);
+                }}
+                disabled={enrichMutation.isPending}
+                aria-label="Review AI suggestions"
+              >
+                {enrichMutation.isPending && enrichTargetId === importRun.id ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Sparkles className="h-4 w-4" />
+                )}
+                <span className="hidden sm:inline">AI suggestions</span>
+              </Button>
+            )}
+
+            {canDelete(importRun) && (
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => setDeleteTarget(importRun)}
+                className="text-destructive hover:text-destructive"
+                aria-label="Delete import"
+              >
+                <Trash2 className="h-4 w-4" />
+              </Button>
+            )}
+          </div>
         </div>
       ))}
+
+      {reviewEnrichmentRunId && (
+        <EnrichmentReviewDialog
+          teamId={teamId}
+          enrichmentRunId={reviewEnrichmentRunId}
+          open={!!reviewEnrichmentRunId}
+          onOpenChange={handleReviewDialogChange}
+        />
+      )}
 
       <AlertDialog open={!!deleteTarget} onOpenChange={() => setDeleteTarget(null)}>
         <AlertDialogContent>

--- a/client/src/components/import-management.tsx
+++ b/client/src/components/import-management.tsx
@@ -13,6 +13,14 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import {
   Trash2,
   Lock,
   Users,
@@ -20,6 +28,7 @@ import {
   AlertCircle,
   Sparkles,
   Loader2,
+  Eye,
 } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { queryClient } from "@/lib/queryClient";
@@ -46,11 +55,23 @@ interface ImportRun {
   teamId: string;
   sourceSystem: string;
   createdByUserId: string;
-  status: "completed" | "failed" | "deleted";
+  status: "pending" | "completed" | "failed" | "deleted";
   options: ImportRunOptions | null;
   stats: ImportRunStats | null;
   createdAt: string;
   importerName: string;
+}
+
+// P2-4 F49: note entry returned by GET /api/teams/:teamId/imports/:importId
+interface ImportRunNote {
+  id: string;
+  title: string;
+  noteType: string;
+  wasUpdated?: boolean;
+}
+
+interface ImportRunDetails extends ImportRun {
+  notes: ImportRunNote[];
 }
 
 interface ImportManagementProps {
@@ -65,6 +86,8 @@ export function ImportManagement({ teamId, isDM, currentUserId }: ImportManageme
   // PRD-016 / P0-4: enrichment run currently open in the review dialog
   const [reviewEnrichmentRunId, setReviewEnrichmentRunId] = useState<string | null>(null);
   const [enrichTargetId, setEnrichTargetId] = useState<string | null>(null);
+  // P2-4 F49: import run currently open in the View Details dialog
+  const [detailsImportId, setDetailsImportId] = useState<string | null>(null);
 
   const { data: imports, isLoading } = useQuery<ImportRun[]>({
     queryKey: ["/api/teams", teamId, "imports"],
@@ -75,6 +98,19 @@ export function ImportManagement({ teamId, isDM, currentUserId }: ImportManageme
       if (!response.ok) throw new Error("Failed to fetch imports");
       return response.json();
     },
+  });
+
+  // P2-4 F49: fetch details (run + its notes) for the View Details dialog
+  const { data: importDetails, isLoading: detailsLoading } = useQuery<ImportRunDetails>({
+    queryKey: ["/api/teams", teamId, "imports", detailsImportId],
+    queryFn: async () => {
+      const response = await fetch(`/api/teams/${teamId}/imports/${detailsImportId}`, {
+        credentials: "include",
+      });
+      if (!response.ok) throw new Error("Failed to fetch import details");
+      return response.json();
+    },
+    enabled: !!detailsImportId,
   });
 
   const deleteMutation = useMutation({
@@ -218,6 +254,15 @@ export function ImportManagement({ teamId, isDM, currentUserId }: ImportManageme
           </div>
 
           <div className="flex items-center gap-1 shrink-0 ml-2">
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => setDetailsImportId(importRun.id)}
+              aria-label="View import details"
+            >
+              <Eye className="h-4 w-4" />
+            </Button>
+
             {importRun.status === "completed" && (
               <Button
                 variant="ghost"
@@ -253,6 +298,64 @@ export function ImportManagement({ teamId, isDM, currentUserId }: ImportManageme
           </div>
         </div>
       ))}
+
+      {/* P2-4 F49: View Details dialog listing the run's notes */}
+      <Dialog
+        open={!!detailsImportId}
+        onOpenChange={(open) => {
+          if (!open) setDetailsImportId(null);
+        }}
+      >
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Import Details</DialogTitle>
+            <DialogDescription>
+              Notes created or updated by this import.
+            </DialogDescription>
+          </DialogHeader>
+          {detailsLoading || !importDetails ? (
+            <div className="py-8 text-center text-muted-foreground">
+              <Loader2 className="h-6 w-6 animate-spin mx-auto mb-2" />
+              <p className="text-sm">Loading import details...</p>
+            </div>
+          ) : (
+            <div className="space-y-3">
+              <p className="text-sm text-muted-foreground">
+                {importDetails.notes.length} note{importDetails.notes.length === 1 ? "" : "s"} in this import
+                {importDetails.stats
+                  ? ` (${importDetails.stats.notesCreated} created, ${importDetails.stats.notesUpdated} updated)`
+                  : ""}
+              </p>
+              <ScrollArea className="h-64 border rounded-lg">
+                <div className="p-2 space-y-1">
+                  {importDetails.notes.length === 0 ? (
+                    <p className="p-2 text-sm text-muted-foreground">
+                      No notes remain from this import.
+                    </p>
+                  ) : (
+                    importDetails.notes.map((note) => (
+                      <div
+                        key={note.id}
+                        className="flex items-center gap-2 p-2 rounded hover:bg-muted/50"
+                      >
+                        <Badge variant="secondary" className="text-xs">
+                          {note.noteType}
+                        </Badge>
+                        <span className="text-sm truncate flex-1">{note.title}</span>
+                        {typeof note.wasUpdated === "boolean" && (
+                          <Badge variant="outline" className="text-xs">
+                            {note.wasUpdated ? "updated" : "created"}
+                          </Badge>
+                        )}
+                      </div>
+                    ))
+                  )}
+                </div>
+              </ScrollArea>
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
 
       {reviewEnrichmentRunId && (
         <EnrichmentReviewDialog

--- a/client/src/components/notes/cleanup-sections.test.tsx
+++ b/client/src/components/notes/cleanup-sections.test.tsx
@@ -1,0 +1,211 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * PRD-049: Relationship Suggestions + Quest Promotion sections in AI Cleanup.
+ */
+import "@testing-library/jest-dom";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import {
+  RelationshipSuggestionsSection,
+  type RelationshipSuggestionStatus,
+} from "./relationship-suggestions-section";
+import {
+  QuestPromotionSection,
+  type QuestSuggestionStatus,
+} from "./quest-promotion-section";
+import type {
+  CleanupQuestSuggestion,
+  CleanupRelationshipSuggestion,
+} from "@shared/cleanup-suggestions";
+
+const relationshipSuggestion: CleanupRelationshipSuggestion = {
+  id: "rel:abc",
+  fromEntityId: "entity:kettle:0",
+  fromEntityText: "Kettle",
+  toEntityId: "entity:silverwood:0",
+  toEntityText: "Silverwood Forest",
+  fromNoteId: "npc-1",
+  toNoteId: "area-1",
+  relationshipType: "NPCInPlace",
+  evidenceType: "Mention",
+  confidence: 0.85,
+  confidenceBucket: "HIGH",
+  snippetText: "Kettle lives near the Silverwood Forest.",
+  sourceBlockId: "auto:xyz",
+  requiresResolution: false,
+};
+
+const questSuggestion: CleanupQuestSuggestion = {
+  id: "quest:def",
+  proposedQuestTitle: "Find Lost Relic",
+  snippetText: "He asked us to Find the Lost Relic before nightfall.",
+  startOffset: 40,
+  endOffset: 60,
+  existingQuestMatches: [
+    { id: "quest-1", title: "Find Lost Relic", noteType: "quest" },
+  ],
+  suggestedNpcNoteId: "npc-1",
+  suggestedAreaNoteId: "area-1",
+};
+
+describe("RelationshipSuggestionsSection (PRD-049 FR-1)", () => {
+  it("renders entity pair, type, evidence, confidence bucket, and snippet", () => {
+    render(
+      <RelationshipSuggestionsSection
+        suggestions={[relationshipSuggestion]}
+        statusById={new Map()}
+        onAccept={vi.fn()}
+        onDismiss={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText("Relationship Suggestions")).toBeInTheDocument();
+    expect(screen.getByText("Kettle")).toBeInTheDocument();
+    expect(screen.getByText("Silverwood Forest")).toBeInTheDocument();
+    expect(screen.getByText("NPC → Place")).toBeInTheDocument();
+    expect(screen.getByText("Mention")).toBeInTheDocument();
+    expect(screen.getByText("High (85%)")).toBeInTheDocument();
+    expect(
+      screen.getByText(/"Kettle lives near the Silverwood Forest\."/)
+    ).toBeInTheDocument();
+  });
+
+  it("invokes accept and dismiss callbacks", () => {
+    const onAccept = vi.fn();
+    const onDismiss = vi.fn();
+    render(
+      <RelationshipSuggestionsSection
+        suggestions={[relationshipSuggestion]}
+        statusById={new Map()}
+        onAccept={onAccept}
+        onDismiss={onDismiss}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Accept/ }));
+    expect(onAccept).toHaveBeenCalledWith(relationshipSuggestion);
+  });
+
+  it("disables Accept until both entities resolve to notes", () => {
+    render(
+      <RelationshipSuggestionsSection
+        suggestions={[
+          { ...relationshipSuggestion, fromNoteId: null, requiresResolution: true },
+        ]}
+        statusById={new Map()}
+        onAccept={vi.fn()}
+        onDismiss={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: /Accept/ })).toBeDisabled();
+    expect(
+      screen.getByText(/Link both entities to existing notes/)
+    ).toBeInTheDocument();
+  });
+
+  it("shows Accepted state and hides dismissed suggestions", () => {
+    const { rerender } = render(
+      <RelationshipSuggestionsSection
+        suggestions={[relationshipSuggestion]}
+        statusById={
+          new Map<string, RelationshipSuggestionStatus>([["rel:abc", "accepted"]])
+        }
+        onAccept={vi.fn()}
+        onDismiss={vi.fn()}
+      />
+    );
+    expect(screen.getByText("Accepted")).toBeInTheDocument();
+
+    rerender(
+      <RelationshipSuggestionsSection
+        suggestions={[relationshipSuggestion]}
+        statusById={
+          new Map<string, RelationshipSuggestionStatus>([["rel:abc", "dismissed"]])
+        }
+        onAccept={vi.fn()}
+        onDismiss={vi.fn()}
+      />
+    );
+    expect(
+      screen.queryByText("Relationship Suggestions")
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("QuestPromotionSection (PRD-049 FR-3)", () => {
+  it("renders proposed title, snippet, and all actions", () => {
+    render(
+      <QuestPromotionSection
+        suggestions={[questSuggestion]}
+        statusById={new Map()}
+        onCreateQuest={vi.fn()}
+        onLinkExistingQuest={vi.fn()}
+        onDismiss={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText("Quest Promotion")).toBeInTheDocument();
+    expect(screen.getByText("Find Lost Relic")).toBeInTheDocument();
+    expect(
+      screen.getByText(/"He asked us to Find the Lost Relic before nightfall\."/)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Create Quest/ })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Link "Find Lost Relic"/ })
+    ).toBeInTheDocument();
+  });
+
+  it("invokes create and link-existing callbacks", () => {
+    const onCreateQuest = vi.fn();
+    const onLinkExistingQuest = vi.fn();
+    render(
+      <QuestPromotionSection
+        suggestions={[questSuggestion]}
+        statusById={new Map()}
+        onCreateQuest={onCreateQuest}
+        onLinkExistingQuest={onLinkExistingQuest}
+        onDismiss={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Create Quest/ }));
+    expect(onCreateQuest).toHaveBeenCalledWith(questSuggestion);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Link "Find Lost Relic"/ })
+    );
+    expect(onLinkExistingQuest).toHaveBeenCalledWith(questSuggestion, "quest-1");
+  });
+
+  it("shows Promoted state and hides dismissed suggestions", () => {
+    const { rerender } = render(
+      <QuestPromotionSection
+        suggestions={[questSuggestion]}
+        statusById={
+          new Map<string, QuestSuggestionStatus>([["quest:def", "promoted"]])
+        }
+        onCreateQuest={vi.fn()}
+        onLinkExistingQuest={vi.fn()}
+        onDismiss={vi.fn()}
+      />
+    );
+    expect(screen.getByText("Promoted")).toBeInTheDocument();
+
+    rerender(
+      <QuestPromotionSection
+        suggestions={[questSuggestion]}
+        statusById={
+          new Map<string, QuestSuggestionStatus>([["quest:def", "dismissed"]])
+        }
+        onCreateQuest={vi.fn()}
+        onLinkExistingQuest={vi.fn()}
+        onDismiss={vi.fn()}
+      />
+    );
+    expect(screen.queryByText("Quest Promotion")).not.toBeInTheDocument();
+  });
+});

--- a/client/src/components/notes/entity-suggestion-card.tsx
+++ b/client/src/components/notes/entity-suggestion-card.tsx
@@ -13,7 +13,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { User, MapPin, ScrollText, Plus, X, Link2, ExternalLink } from "lucide-react";
+import { User, MapPin, ScrollText, Plus, X, Link2, ExternalLink, Undo2, Check } from "lucide-react";
 import type { DetectedEntity, EntityType } from "@shared/entity-detection";
 import type { Note, NoteType } from "@shared/schema";
 
@@ -64,17 +64,29 @@ export const ENTITY_TO_NOTE_TYPE: Record<EntityType, NoteType> = {
   quest: "quest",
 };
 
+// PRD-047 FR-2: linked evidence snippets are truncated for inline display.
+const LINKED_SNIPPET_MAX_LENGTH = 120;
+
+export function truncateSnippet(snippet: string, maxLength = LINKED_SNIPPET_MAX_LENGTH): string {
+  const trimmed = snippet.trim();
+  return trimmed.length > maxLength ? `${trimmed.slice(0, maxLength - 1)}…` : trimmed;
+}
+
 interface EntitySuggestionCardProps {
   entity: DetectedEntity;
   reclassifiedType?: NoteType;
   matchingNotes: Note[];
   isSelected: boolean;
   isLinked?: boolean;
+  /** PRD-047 FR-2: evidence snippet shown inline once linked. */
+  linkedSnippet?: string;
   onSelect: () => void;
   onAccept: (noteType: NoteType) => void;
   onDismiss: () => void;
   onReclassify: (newType: NoteType) => void;
   onLinkToExisting: (noteId: string) => void;
+  /** PRD-047 FR-3: undo removes the backlink created by Link. */
+  onUndoLink?: () => void;
   onOpenNote?: (noteId: string) => void;
 }
 
@@ -84,11 +96,13 @@ export function EntitySuggestionCard({
   matchingNotes,
   isSelected,
   isLinked = false,
+  linkedSnippet,
   onSelect,
   onAccept,
   onDismiss,
   onReclassify,
   onLinkToExisting,
+  onUndoLink,
   onOpenNote,
 }: EntitySuggestionCardProps) {
   const Icon = ENTITY_TYPE_ICONS[entity.type];
@@ -150,6 +164,16 @@ export function EntitySuggestionCard({
         </div>
       )}
 
+      {/* PRD-047 FR-2: evidence snippet shown inline after linking */}
+      {isLinked && linkedSnippet && (
+        <p
+          className="mt-2 text-xs text-muted-foreground italic"
+          data-testid="linked-snippet"
+        >
+          "{truncateSnippet(linkedSnippet)}"
+        </p>
+      )}
+
       {/* Reclassify dropdown */}
       <div className="mt-2">
         <Select
@@ -183,8 +207,23 @@ export function EntitySuggestionCard({
                 className="flex-1 h-7 text-xs"
                 disabled
               >
+                <Check className="h-3 w-3 mr-1" />
                 Linked
               </Button>
+              {onUndoLink && (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="h-7 text-xs px-2"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onUndoLink();
+                  }}
+                >
+                  <Undo2 className="h-3 w-3 mr-1" />
+                  Undo
+                </Button>
+              )}
               {onOpenNote && (
                 <Button
                   size="sm"

--- a/client/src/components/notes/entity-suggestions-panel.test.tsx
+++ b/client/src/components/notes/entity-suggestions-panel.test.tsx
@@ -456,6 +456,24 @@ describe("EntitySuggestionsPanel", () => {
     expect(screen.getByText("AI Cleanup")).toBeInTheDocument();
   });
 
+  // Gap F86: deterministic suggestions must not be gated behind the AI toggle
+  it("shows the Suggestions button for saved sessions even when member AI is disabled", () => {
+    render(
+      <EntitySuggestionsPanel
+        team={mockTeam}
+        sessionDate="2026-01-18"
+        content="Lord Blackwood entered the Silverwood Forest and told us many tales of the region."
+        sessionNote={mockSessionNote}
+        memberAiEnabled={false}
+        onNoteCreated={vi.fn()}
+      />,
+      { wrapper: createWrapper() }
+    );
+
+    expect(screen.getByText("Suggestions")).toBeInTheDocument();
+    expect(screen.queryByText("AI Cleanup")).not.toBeInTheDocument();
+  });
+
   // PRD-047: Link Existing Entity creates a backlink with visible evidence + undo
   describe("link existing entity (PRD-047)", () => {
     const existingNpc = {

--- a/client/src/components/notes/entity-suggestions-panel.test.tsx
+++ b/client/src/components/notes/entity-suggestions-panel.test.tsx
@@ -104,6 +104,7 @@ vi.mock("@/hooks/use-suggestion-persistence", () => ({
     }),
     reclassifyEntity: vi.fn(),
     markCreated: vi.fn(),
+    unmarkCreated: vi.fn(),
     isDismissed: (id: string) => mockPersistenceState.dismissed.has(id),
     getReclassifiedType: () => undefined,
     isCreated: () => false,
@@ -413,7 +414,8 @@ describe("EntitySuggestionsPanel", () => {
         `/api/teams/${mockTeam.id}/notes/new-note-1/backlinks`,
         expect.objectContaining({
           sourceNoteId: mockSessionNote.id,
-          textSnippet: "Lord Blackwood",
+          // PRD-047: snippet is a bounded evidence window around the mention
+          textSnippet: expect.stringContaining("Lord Blackwood"),
           evidenceType: "Mention",
           confidence: 0.8,
         })
@@ -452,5 +454,122 @@ describe("EntitySuggestionsPanel", () => {
     );
 
     expect(screen.getByText("AI Cleanup")).toBeInTheDocument();
+  });
+
+  // PRD-047: Link Existing Entity creates a backlink with visible evidence + undo
+  describe("link existing entity (PRD-047)", () => {
+    const existingNpc = {
+      ...mockSessionNote,
+      id: "npc-9",
+      title: "Lord Blackwood",
+      noteType: "npc" as const,
+    };
+
+    function createSeededWrapper() {
+      const queryClient = new QueryClient({
+        defaultOptions: {
+          queries: {
+            retry: false,
+            staleTime: Infinity,
+          },
+        },
+      });
+      queryClient.setQueryData(
+        ["/api/teams", mockTeam.id, "notes"],
+        [existingNpc]
+      );
+
+      return function Wrapper({ children }: { children: React.ReactNode }) {
+        return (
+          <QueryClientProvider client={queryClient}>
+            {children}
+          </QueryClientProvider>
+        );
+      };
+    }
+
+    function renderPanel() {
+      return render(
+        <EntitySuggestionsPanel
+          team={mockTeam}
+          sessionDate="2026-01-18"
+          content="Lord Blackwood entered the Silverwood Forest."
+          sessionNote={mockSessionNote}
+          memberAiEnabled={false}
+          onNoteCreated={vi.fn()}
+        />,
+        { wrapper: createSeededWrapper() }
+      );
+    }
+
+    it("creates a backlink and shows Linked state with evidence snippet and Undo", async () => {
+      mockApiRequest.mockImplementation(async (method: string, url: string) => {
+        if (
+          method === "POST" &&
+          url === `/api/teams/${mockTeam.id}/notes/npc-9/backlinks`
+        ) {
+          return { json: async () => ({ id: "backlink-9" }) };
+        }
+        throw new Error(`Unexpected request: ${method} ${url}`);
+      });
+
+      renderPanel();
+
+      // Matched entity appears under Existing Entities with a Link action
+      expect(await screen.findByText("Existing Entities")).toBeInTheDocument();
+      fireEvent.click(screen.getByRole("button", { name: /^Link$/ }));
+
+      await waitFor(() => {
+        expect(mockApiRequest).toHaveBeenCalledWith(
+          "POST",
+          `/api/teams/${mockTeam.id}/notes/npc-9/backlinks`,
+          expect.objectContaining({
+            sourceNoteId: mockSessionNote.id,
+            evidenceType: "Mention",
+            confidence: 0.8,
+            textSnippet: expect.stringContaining("Lord Blackwood"),
+          })
+        );
+      });
+
+      // FR-2: row shows Linked state + inline evidence snippet
+      expect(await screen.findByText("Linked")).toBeInTheDocument();
+      expect(screen.getByTestId("linked-snippet")).toHaveTextContent(
+        "Lord Blackwood"
+      );
+      // FR-3: undo is offered
+      expect(screen.getByRole("button", { name: /^Undo$/ })).toBeInTheDocument();
+    });
+
+    it("undo deletes the backlink and reverts the row to actionable", async () => {
+      mockApiRequest.mockImplementation(async (method: string, url: string) => {
+        if (method === "POST") {
+          return { json: async () => ({ id: "backlink-9" }) };
+        }
+        if (
+          method === "DELETE" &&
+          url === `/api/teams/${mockTeam.id}/backlinks/backlink-9`
+        ) {
+          return { json: async () => ({ success: true }) };
+        }
+        throw new Error(`Unexpected request: ${method} ${url}`);
+      });
+
+      renderPanel();
+
+      fireEvent.click(await screen.findByRole("button", { name: /^Link$/ }));
+      fireEvent.click(await screen.findByRole("button", { name: /^Undo$/ }));
+
+      await waitFor(() => {
+        expect(mockApiRequest).toHaveBeenCalledWith(
+          "DELETE",
+          `/api/teams/${mockTeam.id}/backlinks/backlink-9`
+        );
+      });
+
+      // Row is actionable again
+      expect(await screen.findByRole("button", { name: /^Link$/ })).toBeInTheDocument();
+      expect(screen.queryByText("Linked")).not.toBeInTheDocument();
+    });
   });
 });

--- a/client/src/components/notes/entity-suggestions-panel.test.tsx
+++ b/client/src/components/notes/entity-suggestions-panel.test.tsx
@@ -148,6 +148,7 @@ const mockSessionNote = {
   questStatus: null,
   contentBlocks: null,
   sessionDate: null,
+  reviewedAt: null,
   linkedNoteIds: null,
   sourceSystem: null,
   sourcePageId: null,

--- a/client/src/components/notes/entity-suggestions-panel.tsx
+++ b/client/src/components/notes/entity-suggestions-panel.tsx
@@ -136,27 +136,50 @@ export function EntitySuggestionsPanel({
     enabled: true,
   });
 
-  // PRD-026: AI Cleanup mutation
+  // Gap F70/F86 (PRD-026, truth-in-labeling): "Suggestions" runs the
+  // deterministic heuristics endpoint and is NOT gated behind the AI toggle;
+  // "AI Cleanup" below actually calls Haiku.
+  const suggestionsMutation = useMutation({
+    mutationFn: async () => {
+      const response = await apiRequest(
+        "POST",
+        `/api/teams/${team.id}/session-logs/${sessionNoteId}/cleanup-suggestions`,
+        {
+          content,
+          mode: "baseline",
+          includeLow: true,
+        }
+      );
+      return response.json() as Promise<CleanupSuggestionsResponse>;
+    },
+    onSuccess: (data: CleanupSuggestionsResponse, _vars, _ctx) => {
+      setCleanupData(data);
+      toast({
+        title: "Suggestions ready",
+        description: `Found ${data.relationshipSuggestions.length} relationship and ${data.questSuggestions.length} quest suggestions.`,
+      });
+    },
+    onError: () => {
+      toast({
+        title: "Failed to compute suggestions",
+        variant: "destructive",
+      });
+    },
+  });
+
+  // PRD-026: AI Cleanup mutation — always calls the Haiku-backed
+  // extract-entities endpoint (gap F70: it previously ran deterministic
+  // heuristics for saved sessions while claiming to be AI).
   const aiCleanupMutation = useMutation({
     mutationFn: async () => {
-      const response = sessionNoteId
-        ? await apiRequest(
-            "POST",
-            `/api/teams/${team.id}/session-logs/${sessionNoteId}/cleanup-suggestions`,
-            {
-              content,
-              mode: "ai",
-              includeLow: true,
-            }
-          )
-        : await apiRequest(
-            "POST",
-            `/api/teams/${team.id}/extract-entities`,
-            { content }
-          );
+      const response = await apiRequest(
+        "POST",
+        `/api/teams/${team.id}/extract-entities`,
+        { content }
+      );
       return response.json();
     },
-    onSuccess: (data: CleanupSuggestionsResponse | {
+    onSuccess: (data: {
       entities: Array<{
         name: string;
         type: "npc" | "place" | "quest" | "item" | "faction";
@@ -172,25 +195,6 @@ export function EntitySuggestionsPanel({
         confidence: number;
       }>;
     }) => {
-      if ("relationshipSuggestions" in data) {
-        setAiEntities(data.entities);
-        setCleanupData(data);
-        setAiRelationships(
-          data.relationshipSuggestions.map((relationship) => ({
-            entity1: relationship.fromEntityText,
-            entity2: relationship.toEntityText,
-            relationship: relationship.relationshipType,
-            confidence: relationship.confidence,
-          }))
-        );
-
-        toast({
-          title: "AI Cleanup Complete",
-          description: `Found ${data.entities.length} entities, ${data.relationshipSuggestions.length} relationships, and ${data.questSuggestions.length} quest suggestions.`,
-        });
-        return;
-      }
-
       // Convert AI entities to DetectedEntity format
       const converted: DetectedEntity[] = data.entities.map((e, idx) => ({
         id: `ai-${idx}-${e.name.toLowerCase().replace(/\s+/g, "-")}`,
@@ -213,6 +217,11 @@ export function EntitySuggestionsPanel({
         title: "AI Cleanup Complete",
         description: `Found ${data.entities.length} entities and ${data.relationships.length} relationships.`,
       });
+
+      // Refresh the structured suggestion sections alongside the AI results
+      if (sessionNoteId) {
+        suggestionsMutation.mutate();
+      }
     },
     onError: (error: Error & { message?: string }) => {
       // Check for subscription error
@@ -330,6 +339,15 @@ export function EntitySuggestionsPanel({
     },
   });
 
+  // Gap F85 (PRD-049 FR-2): entity detail queries share the
+  // ["/api/teams", teamId, "notes"] prefix, so invalidating it refreshes both
+  // the list and any open entity page after backlink/relationship changes.
+  const invalidateNoteQueries = useCallback(() => {
+    queryClient.invalidateQueries({
+      queryKey: ["/api/teams", team.id, "notes"],
+    });
+  }, [team.id]);
+
   // Create backlink mutation
   const createBacklinkMutation = useMutation({
     mutationFn: async (data: {
@@ -357,6 +375,7 @@ export function EntitySuggestionsPanel({
       );
       return response.json();
     },
+    onSuccess: invalidateNoteQueries,
   });
 
   // PRD-047 FR-3: undo removes the backlink created by Link
@@ -367,6 +386,7 @@ export function EntitySuggestionsPanel({
         `/api/teams/${team.id}/backlinks/${backlinkId}`
       );
     },
+    onSuccess: invalidateNoteQueries,
   });
 
   const createRelationshipMutation = useMutation({
@@ -389,6 +409,7 @@ export function EntitySuggestionsPanel({
       );
       return response.json();
     },
+    onSuccess: invalidateNoteQueries,
   });
 
   // PRD-047: capture a bounded evidence window around a mention (±200 chars)
@@ -408,10 +429,10 @@ export function EntitySuggestionsPanel({
 
   // PRD-049 FR-4: refresh suggestions after link/accept actions without a reload
   const refreshCleanupSuggestions = useCallback(() => {
-    if (cleanupData && sessionNoteId && !aiCleanupMutation.isPending) {
-      aiCleanupMutation.mutate();
+    if (cleanupData && sessionNoteId && !suggestionsMutation.isPending) {
+      suggestionsMutation.mutate();
     }
-  }, [cleanupData, sessionNoteId, aiCleanupMutation]);
+  }, [cleanupData, sessionNoteId, suggestionsMutation]);
 
   // Handle accept action
   const handleAccept = useCallback(
@@ -899,6 +920,9 @@ export function EntitySuggestionsPanel({
       title: "Bulk accept complete",
       description: `Created ${created} entities with ${linked} relationships.`,
     });
+
+    // Gap F87 (PRD-049 FR-4): newly created notes can resolve pending suggestions
+    refreshCleanupSuggestions();
   }, [
     highConfidenceEntities,
     persistence,
@@ -913,6 +937,7 @@ export function EntitySuggestionsPanel({
     sourceImportRunId, // PRD-034
     toast,
     extractEvidenceSnippet,
+    refreshCleanupSuggestions,
   ]);
 
   // Navigate to session review
@@ -983,7 +1008,32 @@ export function EntitySuggestionsPanel({
                     Review All
                   </Button>
                 )}
-                {/* PRD-028: AI Cleanup button - show if member has AI enabled */}
+                {/* Gap F86: deterministic relationship/quest suggestions are
+                    heuristics, not AI - available to every member. */}
+                {sessionNoteId && content.length > 50 && (
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => suggestionsMutation.mutate()}
+                    disabled={suggestionsMutation.isPending}
+                    className="text-xs"
+                  >
+                    {suggestionsMutation.isPending ? (
+                      <Loader2 className="h-3 w-3 mr-1 animate-spin" />
+                    ) : (
+                      <Sparkles className="h-3 w-3 mr-1" />
+                    )}
+                    Suggestions
+                    {cleanupData && (
+                      <Badge variant="secondary" className="ml-1 text-xs">
+                        {cleanupData.relationshipSuggestions.length +
+                          cleanupData.questSuggestions.length}
+                      </Badge>
+                    )}
+                  </Button>
+                )}
+                {/* PRD-028: AI Cleanup button - show if member has AI enabled.
+                    Gap F70: this now always calls the Haiku endpoint. */}
                 {memberAiEnabled && content.length > 50 && (
                   <Button
                     size="sm"

--- a/client/src/components/notes/entity-suggestions-panel.tsx
+++ b/client/src/components/notes/entity-suggestions-panel.tsx
@@ -34,11 +34,25 @@ import { useSuggestionPersistence } from "@/hooks/use-suggestion-persistence";
 import { queryClient, apiRequest } from "@/lib/queryClient";
 import { EntitySuggestionCard, ENTITY_TO_NOTE_TYPE } from "./entity-suggestion-card";
 import { ProximityAssociations } from "./proximity-associations";
+import {
+  RelationshipSuggestionsSection,
+  type RelationshipSuggestionStatus,
+} from "./relationship-suggestions-section";
+import {
+  QuestPromotionSection,
+  type QuestSuggestionStatus,
+} from "./quest-promotion-section";
 import type { Note, NoteType, Team } from "@shared/schema";
 import type { DetectedEntity, EntityType } from "@shared/entity-detection";
 import { matchEntitiesToNotes } from "@shared/entity-detection";
 import { findProximitySuggestions, type ProximitySuggestion } from "@shared/proximity-suggestions";
-import { inferRelationshipTypeForNoteTypes, type CleanupSuggestionsResponse } from "@shared/cleanup-suggestions";
+import {
+  buildFirstSeenSeed,
+  inferRelationshipTypeForNoteTypes,
+  type CleanupQuestSuggestion,
+  type CleanupRelationshipSuggestion,
+  type CleanupSuggestionsResponse,
+} from "@shared/cleanup-suggestions";
 
 interface EntitySuggestionsPanelProps {
   team: Team;
@@ -73,6 +87,20 @@ export function EntitySuggestionsPanel({
   const [linkedExistingEntities, setLinkedExistingEntities] = useState<Set<string>>(
     new Set()
   );
+  // PRD-047 FR-2/FR-3: track created backlinks so we can show evidence and undo.
+  const [linkedBacklinks, setLinkedBacklinks] = useState<
+    Map<string, { backlinkId: string; snippet: string }>
+  >(new Map());
+  // PRD-049: full cleanup suggestions response (relationships + quest promotion)
+  const [cleanupData, setCleanupData] = useState<CleanupSuggestionsResponse | null>(null);
+  const [relationshipStatus, setRelationshipStatus] = useState<
+    Map<string, RelationshipSuggestionStatus>
+  >(new Map());
+  const [questStatus, setQuestStatus] = useState<Map<string, QuestSuggestionStatus>>(
+    new Map()
+  );
+  const [pendingRelationshipId, setPendingRelationshipId] = useState<string | null>(null);
+  const [pendingQuestId, setPendingQuestId] = useState<string | null>(null);
 
   // PRD-026: AI-enhanced entities
   const [aiEntities, setAiEntities] = useState<DetectedEntity[]>([]);
@@ -146,6 +174,7 @@ export function EntitySuggestionsPanel({
     }) => {
       if ("relationshipSuggestions" in data) {
         setAiEntities(data.entities);
+        setCleanupData(data);
         setAiRelationships(
           data.relationshipSuggestions.map((relationship) => ({
             entity1: relationship.fromEntityText,
@@ -157,7 +186,7 @@ export function EntitySuggestionsPanel({
 
         toast({
           title: "AI Cleanup Complete",
-          description: `Found ${data.entities.length} entities and ${data.relationshipSuggestions.length} relationships.`,
+          description: `Found ${data.entities.length} entities, ${data.relationshipSuggestions.length} relationships, and ${data.questSuggestions.length} quest suggestions.`,
         });
         return;
       }
@@ -330,6 +359,16 @@ export function EntitySuggestionsPanel({
     },
   });
 
+  // PRD-047 FR-3: undo removes the backlink created by Link
+  const deleteBacklinkMutation = useMutation({
+    mutationFn: async (backlinkId: string) => {
+      await apiRequest(
+        "DELETE",
+        `/api/teams/${team.id}/backlinks/${backlinkId}`
+      );
+    },
+  });
+
   const createRelationshipMutation = useMutation({
     mutationFn: async (data: {
       fromNoteId: string;
@@ -352,6 +391,28 @@ export function EntitySuggestionsPanel({
     },
   });
 
+  // PRD-047: capture a bounded evidence window around a mention (±200 chars)
+  const extractEvidenceSnippet = useCallback(
+    (
+      mention: { startOffset: number; endOffset: number; text: string } | undefined,
+      fallback: string
+    ): string => {
+      if (!mention || !content) return fallback;
+      const start = Math.max(0, mention.startOffset - 200);
+      const end = Math.min(content.length, mention.endOffset + 200);
+      const snippet = content.slice(start, end).replace(/\s+/g, " ").trim();
+      return snippet || fallback;
+    },
+    [content]
+  );
+
+  // PRD-049 FR-4: refresh suggestions after link/accept actions without a reload
+  const refreshCleanupSuggestions = useCallback(() => {
+    if (cleanupData && sessionNoteId && !aiCleanupMutation.isPending) {
+      aiCleanupMutation.mutate();
+    }
+  }, [cleanupData, sessionNoteId, aiCleanupMutation]);
+
   // Handle accept action
   const handleAccept = useCallback(
     async (entity: DetectedEntity, noteType: NoteType) => {
@@ -362,7 +423,11 @@ export function EntitySuggestionsPanel({
         const linkedNoteIds = Array.from(selectedAssociations);
         const newNote = await createNoteMutation.mutateAsync({
           title: entity.text,
-          content: "",
+          // PRD-048 FR-4: seed content so new entity pages are never blank
+          content: buildFirstSeenSeed(
+            sessionDate,
+            extractEvidenceSnippet(mention, entity.text)
+          ),
           noteType,
           linkedNoteIds: linkedNoteIds.length > 0 ? linkedNoteIds : undefined,
           importRunId: sourceImportRunId, // PRD-034: Track import origin for cascade delete
@@ -373,7 +438,7 @@ export function EntitySuggestionsPanel({
           await createBacklinkMutation.mutateAsync({
             targetNoteId: newNote.id,
             sourceNoteId: sessionNoteId,
-            textSnippet: mention?.text || entity.text,
+            textSnippet: extractEvidenceSnippet(mention, entity.text),
             sourceBlockId: mention?.blockId,
             startOffset: mention?.startOffset,
             endOffset: mention?.endOffset,
@@ -417,6 +482,9 @@ export function EntitySuggestionsPanel({
           title: "Entity created",
           description: `${newNote.title} has been created.`,
         });
+
+        // PRD-049 FR-4: newly created notes can resolve pending suggestions
+        refreshCleanupSuggestions();
       } catch {
         toast({
           title: "Failed to create entity",
@@ -428,26 +496,30 @@ export function EntitySuggestionsPanel({
       selectedAssociations,
       sessionNoteId,
       sourceImportRunId, // PRD-034
+      sessionDate,
       allNotes,
       createNoteMutation,
       createBacklinkMutation,
       createRelationshipMutation,
       persistence,
       toast,
+      extractEvidenceSnippet,
+      refreshCleanupSuggestions,
     ]
   );
 
-  // Handle link to existing
+  // Handle link to existing (PRD-047 FR-1: user-confirmed links are HIGH confidence)
   const handleLinkToExisting = useCallback(
     async (entity: DetectedEntity, noteId: string) => {
       if (!sessionNoteId) return;
 
       try {
         const mention = entity.mentions[0];
-        await createBacklinkMutation.mutateAsync({
+        const snippet = extractEvidenceSnippet(mention, entity.text);
+        const backlink = await createBacklinkMutation.mutateAsync({
           targetNoteId: noteId,
           sourceNoteId: sessionNoteId,
-          textSnippet: mention?.text || entity.text,
+          textSnippet: snippet,
           sourceBlockId: mention?.blockId,
           startOffset: mention?.startOffset,
           endOffset: mention?.endOffset,
@@ -457,11 +529,20 @@ export function EntitySuggestionsPanel({
 
         persistence.markCreated(entity.id);
         setLinkedExistingEntities((prev) => new Set(prev).add(entity.id));
+        // PRD-047 FR-2/FR-3: remember the backlink for inline evidence + undo
+        if (backlink?.id) {
+          setLinkedBacklinks((prev) =>
+            new Map(prev).set(entity.id, { backlinkId: backlink.id, snippet })
+          );
+        }
 
         toast({
           title: "Entity linked",
           description: "Backlink created to existing note.",
         });
+
+        // PRD-049 FR-4: linked entities can resolve pending relationship suggestions
+        refreshCleanupSuggestions();
       } catch {
         toast({
           title: "Failed to link entity",
@@ -469,8 +550,206 @@ export function EntitySuggestionsPanel({
         });
       }
     },
-    [sessionNoteId, createBacklinkMutation, persistence, toast]
+    [
+      sessionNoteId,
+      createBacklinkMutation,
+      persistence,
+      toast,
+      extractEvidenceSnippet,
+      refreshCleanupSuggestions,
+    ]
   );
+
+  // PRD-047 FR-3: undo link removes the backlink and reverts the row
+  const handleUndoLink = useCallback(
+    async (entity: DetectedEntity) => {
+      const linked = linkedBacklinks.get(entity.id);
+      if (!linked) return;
+
+      try {
+        await deleteBacklinkMutation.mutateAsync(linked.backlinkId);
+
+        persistence.unmarkCreated(entity.id);
+        setLinkedExistingEntities((prev) => {
+          const next = new Set(prev);
+          next.delete(entity.id);
+          return next;
+        });
+        setLinkedBacklinks((prev) => {
+          const next = new Map(prev);
+          next.delete(entity.id);
+          return next;
+        });
+
+        toast({
+          title: "Link removed",
+          description: "The backlink has been deleted.",
+        });
+      } catch {
+        toast({
+          title: "Failed to undo link",
+          variant: "destructive",
+        });
+      }
+    },
+    [linkedBacklinks, deleteBacklinkMutation, persistence, toast]
+  );
+
+  // PRD-049 FR-2: accepting a relationship suggestion persists it
+  const handleAcceptRelationship = useCallback(
+    async (suggestion: CleanupRelationshipSuggestion) => {
+      if (!sessionNoteId || !suggestion.fromNoteId || !suggestion.toNoteId) return;
+
+      setPendingRelationshipId(suggestion.id);
+      try {
+        await createRelationshipMutation.mutateAsync({
+          fromNoteId: suggestion.fromNoteId,
+          toNoteId: suggestion.toNoteId,
+          relationshipType: suggestion.relationshipType,
+          evidenceType: suggestion.evidenceType,
+          confidence: suggestion.confidence,
+          sourceNoteId: sessionNoteId,
+          snippetText: suggestion.snippetText,
+          sourceBlockId: suggestion.sourceBlockId,
+        });
+
+        setRelationshipStatus((prev) => new Map(prev).set(suggestion.id, "accepted"));
+        toast({
+          title: "Relationship saved",
+          description: `${suggestion.fromEntityText} → ${suggestion.toEntityText}`,
+        });
+      } catch {
+        toast({
+          title: "Failed to save relationship",
+          variant: "destructive",
+        });
+      } finally {
+        setPendingRelationshipId(null);
+      }
+    },
+    [sessionNoteId, createRelationshipMutation, toast]
+  );
+
+  const handleDismissRelationship = useCallback(
+    (suggestion: CleanupRelationshipSuggestion) => {
+      setRelationshipStatus((prev) => new Map(prev).set(suggestion.id, "dismissed"));
+    },
+    []
+  );
+
+  // PRD-049 FR-3: promote actionable text to a Quest note with auto-links
+  const handleCreateQuest = useCallback(
+    async (suggestion: CleanupQuestSuggestion) => {
+      setPendingQuestId(suggestion.id);
+      try {
+        const questNote = await createNoteMutation.mutateAsync({
+          title: suggestion.proposedQuestTitle,
+          content: buildFirstSeenSeed(sessionDate, suggestion.snippetText),
+          noteType: "quest",
+          importRunId: sourceImportRunId,
+        });
+
+        if (sessionNoteId) {
+          // Backlink from session → quest (Mention evidence)
+          await createBacklinkMutation.mutateAsync({
+            targetNoteId: questNote.id,
+            sourceNoteId: sessionNoteId,
+            textSnippet: suggestion.snippetText,
+            startOffset: suggestion.startOffset,
+            endOffset: suggestion.endOffset,
+            evidenceType: "Mention",
+            confidence: 0.8,
+          });
+
+          if (suggestion.suggestedNpcNoteId) {
+            await createRelationshipMutation.mutateAsync({
+              fromNoteId: questNote.id,
+              toNoteId: suggestion.suggestedNpcNoteId,
+              relationshipType: "QuestHasNPC",
+              evidenceType: "Heuristic",
+              confidence: 0.72,
+              sourceNoteId: sessionNoteId,
+              snippetText: suggestion.snippetText,
+            });
+          }
+
+          if (suggestion.suggestedAreaNoteId) {
+            await createRelationshipMutation.mutateAsync({
+              fromNoteId: questNote.id,
+              toNoteId: suggestion.suggestedAreaNoteId,
+              relationshipType: "QuestAtPlace",
+              evidenceType: "Heuristic",
+              confidence: 0.72,
+              sourceNoteId: sessionNoteId,
+              snippetText: suggestion.snippetText,
+            });
+          }
+        }
+
+        setQuestStatus((prev) => new Map(prev).set(suggestion.id, "promoted"));
+        toast({
+          title: "Quest created",
+          description: `${questNote.title} has been created and linked.`,
+        });
+
+        refreshCleanupSuggestions();
+      } catch {
+        toast({
+          title: "Failed to create quest",
+          variant: "destructive",
+        });
+      } finally {
+        setPendingQuestId(null);
+      }
+    },
+    [
+      sessionNoteId,
+      sessionDate,
+      sourceImportRunId,
+      createNoteMutation,
+      createBacklinkMutation,
+      createRelationshipMutation,
+      toast,
+      refreshCleanupSuggestions,
+    ]
+  );
+
+  const handleLinkExistingQuest = useCallback(
+    async (suggestion: CleanupQuestSuggestion, questNoteId: string) => {
+      if (!sessionNoteId) return;
+
+      setPendingQuestId(suggestion.id);
+      try {
+        await createBacklinkMutation.mutateAsync({
+          targetNoteId: questNoteId,
+          sourceNoteId: sessionNoteId,
+          textSnippet: suggestion.snippetText,
+          startOffset: suggestion.startOffset,
+          endOffset: suggestion.endOffset,
+          evidenceType: "Mention",
+          confidence: 0.8,
+        });
+
+        setQuestStatus((prev) => new Map(prev).set(suggestion.id, "promoted"));
+        toast({
+          title: "Quest linked",
+          description: "The session has been linked to the existing quest.",
+        });
+      } catch {
+        toast({
+          title: "Failed to link quest",
+          variant: "destructive",
+        });
+      } finally {
+        setPendingQuestId(null);
+      }
+    },
+    [sessionNoteId, createBacklinkMutation, toast]
+  );
+
+  const handleDismissQuest = useCallback((suggestion: CleanupQuestSuggestion) => {
+    setQuestStatus((prev) => new Map(prev).set(suggestion.id, "dismissed"));
+  }, []);
 
   // Handle dismiss
   const handleDismiss = useCallback(
@@ -562,7 +841,11 @@ export function EntitySuggestionsPanel({
 
         const newNote = await createNoteMutation.mutateAsync({
           title: entity.text,
-          content: "",
+          // PRD-048 FR-4: seed content so new entity pages are never blank
+          content: buildFirstSeenSeed(
+            sessionDate,
+            extractEvidenceSnippet(mention, entity.text)
+          ),
           noteType,
           linkedNoteIds: linkedNoteIds.length > 0 ? linkedNoteIds : undefined,
           importRunId: sourceImportRunId, // PRD-034: Track import origin for cascade delete
@@ -572,7 +855,7 @@ export function EntitySuggestionsPanel({
           await createBacklinkMutation.mutateAsync({
             targetNoteId: newNote.id,
             sourceNoteId: sessionNoteId,
-            textSnippet: mention?.text || entity.text,
+            textSnippet: extractEvidenceSnippet(mention, entity.text),
             sourceBlockId: mention?.blockId,
             startOffset: mention?.startOffset,
             endOffset: mention?.endOffset,
@@ -626,8 +909,10 @@ export function EntitySuggestionsPanel({
     createRelationshipMutation,
     allNotes,
     sessionNoteId,
+    sessionDate,
     sourceImportRunId, // PRD-034
     toast,
+    extractEvidenceSnippet,
   ]);
 
   // Navigate to session review
@@ -815,6 +1100,7 @@ export function EntitySuggestionsPanel({
                           linkedExistingEntities.has(entity.id) ||
                           persistence.isCreated(entity.id)
                         }
+                        linkedSnippet={linkedBacklinks.get(entity.id)?.snippet}
                         onSelect={() => handleSelectEntity(entity)}
                         onAccept={(noteType) => handleAccept(entity, noteType)}
                         onDismiss={() => handleDismiss(entity.id)}
@@ -824,12 +1110,40 @@ export function EntitySuggestionsPanel({
                         onLinkToExisting={(noteId) =>
                           handleLinkToExisting(entity, noteId)
                         }
+                        onUndoLink={
+                          linkedBacklinks.has(entity.id)
+                            ? () => handleUndoLink(entity)
+                            : undefined
+                        }
                         onOpenNote={onOpenNote}
                       />
                     );
                   })}
                 </div>
               </div>
+            )}
+
+            {/* PRD-049 FR-1: relationship suggestions with Accept/Dismiss */}
+            {cleanupData && (
+              <RelationshipSuggestionsSection
+                suggestions={cleanupData.relationshipSuggestions}
+                statusById={relationshipStatus}
+                pendingId={pendingRelationshipId}
+                onAccept={handleAcceptRelationship}
+                onDismiss={handleDismissRelationship}
+              />
+            )}
+
+            {/* PRD-049 FR-3: quest promotion from actionable text */}
+            {cleanupData && (
+              <QuestPromotionSection
+                suggestions={cleanupData.questSuggestions}
+                statusById={questStatus}
+                pendingId={pendingQuestId}
+                onCreateQuest={handleCreateQuest}
+                onLinkExistingQuest={handleLinkExistingQuest}
+                onDismiss={handleDismissQuest}
+              />
             )}
           </div>
         </CollapsibleContent>

--- a/client/src/components/notes/imported-note-view.test.tsx
+++ b/client/src/components/notes/imported-note-view.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Gap F47 (PRD-015 FR-4): imported notes render resolved markdown with
+ * navigable internal links.
+ */
+import "@testing-library/jest-dom";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ImportedNoteView } from "./imported-note-view";
+import type { Note } from "@shared/schema";
+
+const baseNote = {
+  id: "note-1",
+  teamId: "team-1",
+  title: "Kettle",
+  noteType: "npc",
+  content: "raw [Kettle](<Kettle 03183b35.md?n>) syntax",
+  sourceSystem: "NUCLINO",
+  contentMarkdownResolved:
+    "# Kettle\n\nA friendly innkeeper. See [The Tavern](/notes/note-tavern) and [Ghost Page](#unresolved).\n\n- Runs the inn\n- Knows rumors",
+} as Note;
+
+describe("ImportedNoteView", () => {
+  it("renders resolved markdown instead of raw link syntax", () => {
+    render(<ImportedNoteView note={baseNote} onEdit={vi.fn()} />);
+
+    expect(screen.getByText("Kettle")).toBeInTheDocument();
+    expect(screen.getByText("A friendly innkeeper.", { exact: false })).toBeInTheDocument();
+    expect(screen.getByText("Runs the inn")).toBeInTheDocument();
+    // Raw Nuclino syntax should not appear anywhere
+    expect(screen.queryByText(/03183b35\.md/)).not.toBeInTheDocument();
+  });
+
+  it("navigates internal /notes/:id links through onOpenNote", () => {
+    const onOpenNote = vi.fn();
+    render(<ImportedNoteView note={baseNote} onOpenNote={onOpenNote} onEdit={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "The Tavern" }));
+    expect(onOpenNote).toHaveBeenCalledWith("note-tavern");
+  });
+
+  it("renders unresolved links as non-navigable muted text", () => {
+    render(<ImportedNoteView note={baseNote} onEdit={vi.fn()} />);
+
+    const ghost = screen.getByText("Ghost Page");
+    expect(ghost.tagName).toBe("SPAN");
+    expect(ghost).toHaveAttribute("title", expect.stringContaining("not part of the import"));
+  });
+
+  it("offers an Edit action", () => {
+    const onEdit = vi.fn();
+    render(<ImportedNoteView note={baseNote} onEdit={onEdit} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Edit/ }));
+    expect(onEdit).toHaveBeenCalled();
+  });
+
+  it("falls back to plain content when no resolved markdown exists", () => {
+    const note = { ...baseNote, contentMarkdownResolved: null } as Note;
+    render(<ImportedNoteView note={note} onEdit={vi.fn()} />);
+    expect(screen.getByText(/raw/, { exact: false })).toBeInTheDocument();
+  });
+});

--- a/client/src/components/notes/imported-note-view.tsx
+++ b/client/src/components/notes/imported-note-view.tsx
@@ -1,0 +1,86 @@
+import { useMemo } from "react";
+import ReactMarkdown from "react-markdown";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Pencil, BookOpen } from "lucide-react";
+import type { Note } from "@shared/schema";
+
+interface ImportedNoteViewProps {
+  note: Note;
+  onOpenNote?: (noteId: string) => void;
+  onEdit: () => void;
+}
+
+/**
+ * Gap F47 (PRD-015 FR-4/AC-3/AC-4): imported notes store link-resolved markdown
+ * in contentMarkdownResolved, but it was never rendered — users saw raw
+ * Nuclino "[text](page.md?n)" syntax in a plain textarea. This read-mode view
+ * renders the resolved markdown with internal /notes/:id links wired to
+ * in-app navigation. Unresolved links render as muted, non-navigable text.
+ */
+export function ImportedNoteView({ note, onOpenNote, onEdit }: ImportedNoteViewProps) {
+  const markdown = note.contentMarkdownResolved || note.content || "";
+
+  const components = useMemo(
+    () => ({
+      a: ({ href, children }: { href?: string; children?: React.ReactNode }) => {
+        if (href?.startsWith("/notes/")) {
+          const noteId = href.slice("/notes/".length);
+          return (
+            <button
+              type="button"
+              className="text-primary underline underline-offset-2 hover:opacity-80"
+              onClick={() => onOpenNote?.(noteId)}
+            >
+              {children}
+            </button>
+          );
+        }
+        if (href === "#unresolved") {
+          return (
+            <span
+              className="text-muted-foreground border-b border-dotted border-muted-foreground/50 cursor-default"
+              title="This link's target page was not part of the import"
+            >
+              {children}
+            </span>
+          );
+        }
+        return (
+          <a
+            href={href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary underline underline-offset-2 hover:opacity-80"
+          >
+            {children}
+          </a>
+        );
+      },
+    }),
+    [onOpenNote]
+  );
+
+  return (
+    <div className="space-y-2" data-testid="imported-note-view">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <BookOpen className="h-3.5 w-3.5" />
+          <span>Imported page</span>
+          {note.sourceSystem && (
+            <Badge variant="secondary" className="text-xs py-0 px-1.5">
+              {note.sourceSystem}
+            </Badge>
+          )}
+        </div>
+        <Button size="sm" variant="outline" className="h-7 text-xs" onClick={onEdit}>
+          <Pencil className="h-3 w-3 mr-1" />
+          Edit
+        </Button>
+      </div>
+      <div className="prose prose-sm dark:prose-invert max-w-none rounded-lg border bg-muted/30 p-4 [&_h1]:text-xl [&_h1]:font-semibold [&_h1]:mt-2 [&_h2]:text-lg [&_h2]:font-semibold [&_h3]:text-base [&_h3]:font-medium [&_ul]:list-disc [&_ul]:pl-5 [&_ol]:list-decimal [&_ol]:pl-5 [&_p]:my-2 [&_li]:my-0.5">
+        <ReactMarkdown components={components}>{markdown}</ReactMarkdown>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/notes/note-detail-sections.test.tsx
+++ b/client/src/components/notes/note-detail-sections.test.tsx
@@ -115,7 +115,23 @@ describe("NoteDetailSections session references (PRD-048 FR-2/FR-5)", () => {
     renderSections({ onOpenNote });
 
     fireEvent.click(await screen.findByText("Session 2026-06-20"));
-    expect(onOpenNote).toHaveBeenCalledWith("session-1");
+    expect(onOpenNote).toHaveBeenCalledWith("session-1", undefined);
+  });
+
+  // P2-2 (PRD-005 FR-3): offsets travel with the navigation for scroll-to-mention
+  it("passes mention offsets with the navigation when the backlink has them", async () => {
+    detailFixture.referencesIn = [
+      {
+        ...(detailFixture.referencesIn![0] as object),
+        startOffset: 42,
+        endOffset: 48,
+      },
+    ] as NoteDetailResponse["referencesIn"];
+    const onOpenNote = vi.fn();
+    renderSections({ onOpenNote });
+
+    fireEvent.click(await screen.findByText("Session 2026-06-20"));
+    expect(onOpenNote).toHaveBeenCalledWith("session-1", { start: 42, end: 48 });
   });
 });
 

--- a/client/src/components/notes/note-detail-sections.test.tsx
+++ b/client/src/components/notes/note-detail-sections.test.tsx
@@ -172,6 +172,44 @@ describe("NoteDetailSections relationships (PRD-048 FR-3)", () => {
     });
   });
 
+  // Gap F64/F89 (PRD-016): pending AI edges are badged, rejected ones hidden
+  it("badges pending AI-enrichment edges and hides rejected ones", async () => {
+    detailFixture.relationships = [
+      {
+        id: "rel-pending",
+        fromNoteId: "quest-1",
+        toNoteId: "npc-1",
+        relationshipType: "QuestHasNPC",
+        evidenceType: "Heuristic",
+        evidenceSnippet: null,
+        confidence: 0.7,
+        createdByUserId: "user-2",
+        status: "pending",
+        fromNote: { id: "quest-1", title: "Pending Quest", noteType: "quest" },
+        toNote: { id: "npc-1", title: "Kettle", noteType: "npc" },
+      },
+      {
+        id: "rel-rejected",
+        fromNoteId: "quest-2",
+        toNoteId: "npc-1",
+        relationshipType: "QuestHasNPC",
+        evidenceType: "Heuristic",
+        evidenceSnippet: null,
+        confidence: 0.7,
+        createdByUserId: "user-2",
+        status: "rejected",
+        fromNote: { id: "quest-2", title: "Rejected Quest", noteType: "quest" },
+        toNote: { id: "npc-1", title: "Kettle", noteType: "npc" },
+      },
+    ] as NoteDetailResponse["relationships"];
+
+    renderSections();
+
+    expect(await screen.findByText("Pending Quest")).toBeInTheDocument();
+    expect(screen.getByText("Pending AI review")).toBeInTheDocument();
+    expect(screen.queryByText("Rejected Quest")).not.toBeInTheDocument();
+  });
+
   it("lets the DM delete the relationship", async () => {
     mockApiRequest.mockResolvedValue({});
     renderSections({ userId: "user-1", isDm: true });

--- a/client/src/components/notes/note-detail-sections.test.tsx
+++ b/client/src/components/notes/note-detail-sections.test.tsx
@@ -1,0 +1,183 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * PRD-048: entity pages show Referenced in Sessions + Relationships with
+ * informative empty states, grouping, confidence buckets, and role-gated
+ * relationship deletion.
+ */
+import "@testing-library/jest-dom";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { NoteDetailSections, type NoteDetailResponse } from "./note-detail-sections";
+import type { Note, Team } from "@shared/schema";
+
+const mockApiRequest = vi.fn();
+vi.mock("@/lib/queryClient", () => ({
+  queryClient: {
+    invalidateQueries: vi.fn(),
+  },
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+}));
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+const mockTeam = { id: "team-1", name: "Test Team" } as Team;
+
+const mockNote = {
+  id: "npc-1",
+  teamId: "team-1",
+  title: "Kettle",
+  noteType: "npc",
+  content: "",
+} as Note;
+
+let detailFixture: Partial<NoteDetailResponse>;
+
+function renderSections(props?: Partial<Parameters<typeof NoteDetailSections>[0]>) {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: {
+        queryFn: async () => detailFixture,
+        retry: false,
+        staleTime: Infinity,
+      },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={client}>
+      <NoteDetailSections
+        team={mockTeam}
+        note={mockNote}
+        userId="user-1"
+        isDm={false}
+        {...props}
+      />
+    </QueryClientProvider>
+  );
+}
+
+beforeEach(() => {
+  mockApiRequest.mockReset();
+  detailFixture = {
+    ...mockNote,
+    referencesIn: [],
+    referencesOut: [],
+    relationships: [],
+  };
+});
+
+describe("NoteDetailSections empty states (PRD-048 FR-1)", () => {
+  it("renders both sections with informative empty states", async () => {
+    renderSections();
+
+    expect(await screen.findByText("Referenced in Sessions")).toBeInTheDocument();
+    expect(screen.getByText("Relationships")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Not referenced in any sessions yet/)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/No relationships yet/)).toBeInTheDocument();
+  });
+});
+
+describe("NoteDetailSections session references (PRD-048 FR-2/FR-5)", () => {
+  beforeEach(() => {
+    detailFixture.referencesIn = [
+      {
+        id: "backlink-1",
+        sourceNoteId: "session-1",
+        sourceNoteTitle: "Session 2026-06-20",
+        sourceNoteType: "session_log",
+        sourceNoteSessionDate: "2026-06-20T00:00:00.000Z",
+        createdByName: "Ronnie G",
+        textSnippet: "Kettle greeted the party warmly.",
+        snippetPreview: "Kettle greeted the party warmly.",
+        createdAt: "2026-06-20T01:00:00.000Z",
+      },
+    ] as NoteDetailResponse["referencesIn"];
+  });
+
+  it("shows session title, snippet, and author", async () => {
+    renderSections();
+
+    expect(await screen.findByText("Session 2026-06-20")).toBeInTheDocument();
+    expect(
+      screen.getByText(/"Kettle greeted the party warmly."/)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/added by Ronnie G/)).toBeInTheDocument();
+  });
+
+  it("navigates to the session note when clicked", async () => {
+    const onOpenNote = vi.fn();
+    renderSections({ onOpenNote });
+
+    fireEvent.click(await screen.findByText("Session 2026-06-20"));
+    expect(onOpenNote).toHaveBeenCalledWith("session-1");
+  });
+});
+
+describe("NoteDetailSections relationships (PRD-048 FR-3)", () => {
+  beforeEach(() => {
+    detailFixture.relationships = [
+      {
+        id: "rel-1",
+        fromNoteId: "quest-1",
+        toNoteId: "npc-1",
+        relationshipType: "QuestHasNPC",
+        evidenceType: "Heuristic",
+        evidenceSnippet: "Kettle asked us to find the relic",
+        confidence: 0.72,
+        createdByUserId: "user-2",
+        fromNote: { id: "quest-1", title: "Find the Relic", noteType: "quest" },
+        toNote: { id: "npc-1", title: "Kettle", noteType: "npc" },
+      },
+    ] as NoteDetailResponse["relationships"];
+  });
+
+  it("groups by relationship type and shows evidence + confidence bucket", async () => {
+    renderSections();
+
+    expect(await screen.findByText("Quest ↔ NPC")).toBeInTheDocument();
+    expect(screen.getByText("Find the Relic")).toBeInTheDocument();
+    expect(screen.getByText("Heuristic")).toBeInTheDocument();
+    // 0.72 buckets as REVIEW -> "Needs review"
+    expect(screen.getByText("Needs review")).toBeInTheDocument();
+  });
+
+  it("hides the delete action for non-creator non-DM members", async () => {
+    renderSections({ userId: "user-1", isDm: false });
+
+    await screen.findByText("Find the Relic");
+    expect(
+      screen.queryByRole("button", { name: /remove relationship/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("lets the creator delete the relationship", async () => {
+    mockApiRequest.mockResolvedValue({});
+    renderSections({ userId: "user-2", isDm: false });
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: /remove relationship/i })
+    );
+
+    await waitFor(() => {
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        "DELETE",
+        `/api/teams/${mockTeam.id}/relationships/rel-1`
+      );
+    });
+  });
+
+  it("lets the DM delete the relationship", async () => {
+    mockApiRequest.mockResolvedValue({});
+    renderSections({ userId: "user-1", isDm: true });
+
+    expect(
+      await screen.findByRole("button", { name: /remove relationship/i })
+    ).toBeInTheDocument();
+  });
+});

--- a/client/src/components/notes/note-detail-sections.tsx
+++ b/client/src/components/notes/note-detail-sections.tsx
@@ -13,6 +13,8 @@ interface NoteDetailReferenceIn {
   id: string;
   sourceNoteId: string;
   sourceBlockId?: string | null;
+  startOffset?: number | null;
+  endOffset?: number | null;
   sourceNoteTitle: string | null;
   sourceNoteType: string | null;
   sourceNoteSessionDate: string | null;
@@ -74,7 +76,9 @@ interface NoteDetailSectionsProps {
   note: Note;
   userId: string;
   isDm: boolean;
-  onOpenNote?: (noteId: string) => void;
+  /** P2-2 (PRD-005 FR-3): highlight carries the mention offsets so the editor
+      can scroll to and select the exact reference. */
+  onOpenNote?: (noteId: string, highlight?: { start: number; end: number }) => void;
 }
 
 /**
@@ -174,7 +178,14 @@ export function NoteDetailSections({
               <button
                 key={reference.id}
                 type="button"
-                onClick={() => onOpenNote?.(reference.sourceNoteId)}
+                onClick={() =>
+                  onOpenNote?.(
+                    reference.sourceNoteId,
+                    reference.startOffset != null && reference.endOffset != null
+                      ? { start: reference.startOffset, end: reference.endOffset }
+                      : undefined
+                  )
+                }
                 className="w-full text-left p-3 rounded-lg border bg-muted/50 hover:bg-muted transition-colors"
                 data-testid={`session-reference-${reference.id}`}
               >

--- a/client/src/components/notes/note-detail-sections.tsx
+++ b/client/src/components/notes/note-detail-sections.tsx
@@ -1,0 +1,298 @@
+import { useMemo } from "react";
+import { useQuery, useMutation } from "@tanstack/react-query";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { BookOpen, Share2, ExternalLink, Trash2 } from "lucide-react";
+import { useToast } from "@/hooks/use-toast";
+import { queryClient, apiRequest } from "@/lib/queryClient";
+import { confidenceBucket, type ConfidenceBucket } from "@shared/cleanup-suggestions";
+import type { Note, Team } from "@shared/schema";
+
+interface NoteDetailReferenceIn {
+  id: string;
+  sourceNoteId: string;
+  sourceBlockId?: string | null;
+  sourceNoteTitle: string | null;
+  sourceNoteType: string | null;
+  sourceNoteSessionDate: string | null;
+  createdByName: string | null;
+  textSnippet: string | null;
+  snippetPreview: string | null;
+  createdAt: string;
+}
+
+interface NoteDetailRelationshipEnd {
+  id: string;
+  title: string | null;
+  noteType: string | null;
+  hidden?: boolean;
+}
+
+interface NoteDetailRelationship {
+  id: string;
+  fromNoteId: string;
+  toNoteId: string;
+  relationshipType: string;
+  evidenceType: string | null;
+  evidenceSnippet: string | null;
+  confidence: number | null;
+  createdByUserId: string | null;
+  fromNote: NoteDetailRelationshipEnd;
+  toNote: NoteDetailRelationshipEnd;
+}
+
+export interface NoteDetailResponse extends Note {
+  referencesIn: NoteDetailReferenceIn[];
+  referencesOut: unknown[];
+  relationships: NoteDetailRelationship[];
+}
+
+const BUCKET_STYLES: Record<ConfidenceBucket, string> = {
+  HIGH: "bg-green-500/10 text-green-600 border-green-500/20",
+  REVIEW: "bg-amber-500/10 text-amber-600 border-amber-500/20",
+  LOW: "bg-gray-500/10 text-gray-500 border-gray-500/20",
+};
+
+const BUCKET_LABELS: Record<ConfidenceBucket, string> = {
+  HIGH: "High",
+  REVIEW: "Needs review",
+  LOW: "Low",
+};
+
+const RELATIONSHIP_GROUP_LABELS: Record<string, string> = {
+  QuestHasNPC: "Quest ↔ NPC",
+  QuestAtPlace: "Quest ↔ Place",
+  NPCInPlace: "NPC ↔ Place",
+  Related: "Related",
+};
+
+interface NoteDetailSectionsProps {
+  team: Team;
+  note: Note;
+  userId: string;
+  isDm: boolean;
+  onOpenNote?: (noteId: string) => void;
+}
+
+/**
+ * PRD-048: "Referenced in Sessions" + "Relationships" sections rendered on
+ * entity pages (NPC/Area/Quest/POI/...). Both sections always render with
+ * informative empty states so entity pages are never blank.
+ */
+export function NoteDetailSections({
+  team,
+  note,
+  userId,
+  isDm,
+  onOpenNote,
+}: NoteDetailSectionsProps) {
+  const { toast } = useToast();
+
+  const detailQueryKey = ["/api/teams", team.id, "notes", note.id];
+  const { data: detail, isLoading } = useQuery<NoteDetailResponse>({
+    queryKey: detailQueryKey,
+    enabled: !!team.id && !!note.id,
+  });
+
+  const deleteRelationshipMutation = useMutation({
+    mutationFn: async (relationshipId: string) => {
+      await apiRequest(
+        "DELETE",
+        `/api/teams/${team.id}/relationships/${relationshipId}`
+      );
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: detailQueryKey });
+      toast({
+        title: "Relationship removed",
+      });
+    },
+    onError: () => {
+      toast({
+        title: "Failed to remove relationship",
+        variant: "destructive",
+      });
+    },
+  });
+
+  // PRD-048 FR-1c: group relationships by type
+  const groupedRelationships = useMemo(() => {
+    const groups = new Map<string, NoteDetailRelationship[]>();
+    for (const relationship of detail?.relationships ?? []) {
+      const group = groups.get(relationship.relationshipType) ?? [];
+      group.push(relationship);
+      groups.set(relationship.relationshipType, group);
+    }
+    return groups;
+  }, [detail?.relationships]);
+
+  if (isLoading) {
+    return (
+      <div className="space-y-3 border-t mt-4 pt-4">
+        <Skeleton className="h-16 w-full" />
+        <Skeleton className="h-16 w-full" />
+      </div>
+    );
+  }
+
+  const referencesIn = detail?.referencesIn ?? [];
+  const relationships = detail?.relationships ?? [];
+
+  return (
+    <div className="space-y-4 border-t mt-4 pt-4">
+      {/* PRD-048 FR-1b / FR-2: Referenced in Sessions */}
+      <div className="space-y-2" data-testid="referenced-in-sessions">
+        <h4 className="text-sm font-medium text-muted-foreground flex items-center gap-2">
+          <BookOpen className="h-4 w-4" />
+          Referenced in Sessions
+          {referencesIn.length > 0 && (
+            <Badge variant="secondary" className="text-xs">
+              {referencesIn.length}
+            </Badge>
+          )}
+        </h4>
+        {referencesIn.length === 0 ? (
+          <p className="text-sm text-muted-foreground py-2">
+            Not referenced in any sessions yet. Link mentions from session
+            notes to see them here.
+          </p>
+        ) : (
+          <div className="space-y-2 max-h-60 overflow-auto">
+            {referencesIn.map((reference) => (
+              <button
+                key={reference.id}
+                type="button"
+                onClick={() => onOpenNote?.(reference.sourceNoteId)}
+                className="w-full text-left p-3 rounded-lg border bg-muted/50 hover:bg-muted transition-colors"
+                data-testid={`session-reference-${reference.id}`}
+              >
+                <div className="flex items-center gap-2">
+                  <span className="font-medium truncate text-sm">
+                    {reference.sourceNoteTitle || "Private note"}
+                  </span>
+                  <ExternalLink className="h-3 w-3 text-muted-foreground flex-shrink-0" />
+                </div>
+                {reference.textSnippet && (
+                  <p className="text-xs text-muted-foreground mt-1 line-clamp-2 italic">
+                    "{reference.textSnippet}"
+                  </p>
+                )}
+                <div className="flex items-center gap-2 mt-1.5 text-xs text-muted-foreground">
+                  <span>
+                    {reference.sourceNoteSessionDate
+                      ? new Date(reference.sourceNoteSessionDate).toLocaleDateString()
+                      : new Date(reference.createdAt).toLocaleDateString()}
+                  </span>
+                  {reference.createdByName && (
+                    <>
+                      <span>·</span>
+                      <span>added by {reference.createdByName}</span>
+                    </>
+                  )}
+                </div>
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* PRD-048 FR-1c / FR-3: Relationships */}
+      <div className="space-y-2" data-testid="relationships-section">
+        <h4 className="text-sm font-medium text-muted-foreground flex items-center gap-2">
+          <Share2 className="h-4 w-4" />
+          Relationships
+          {relationships.length > 0 && (
+            <Badge variant="secondary" className="text-xs">
+              {relationships.length}
+            </Badge>
+          )}
+        </h4>
+        {relationships.length === 0 ? (
+          <p className="text-sm text-muted-foreground py-2">
+            No relationships yet. Accept relationship suggestions from session
+            notes or import linked pages to connect this entity.
+          </p>
+        ) : (
+          <div className="space-y-3">
+            {Array.from(groupedRelationships.entries()).map(([type, group]) => (
+              <div key={type} className="space-y-1.5">
+                <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                  {RELATIONSHIP_GROUP_LABELS[type] || type}
+                </p>
+                {group.map((relationship) => {
+                  const isOutgoing = relationship.fromNoteId === note.id;
+                  const otherEnd = isOutgoing
+                    ? relationship.toNote
+                    : relationship.fromNote;
+                  const bucket =
+                    relationship.confidence != null
+                      ? confidenceBucket(relationship.confidence)
+                      : null;
+                  const canDelete =
+                    isDm || relationship.createdByUserId === userId;
+
+                  return (
+                    <div
+                      key={relationship.id}
+                      className="p-2.5 rounded-lg border flex items-start justify-between gap-2"
+                      data-testid={`relationship-${relationship.id}`}
+                    >
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-center gap-2 flex-wrap">
+                          <button
+                            type="button"
+                            className="text-sm font-medium hover:underline truncate"
+                            onClick={() =>
+                              !otherEnd.hidden && onOpenNote?.(otherEnd.id)
+                            }
+                          >
+                            {otherEnd.hidden
+                              ? "Private note"
+                              : otherEnd.title || "Untitled"}
+                          </button>
+                          {relationship.evidenceType && (
+                            <Badge variant="outline" className="text-xs py-0 px-1.5">
+                              {relationship.evidenceType}
+                            </Badge>
+                          )}
+                          {bucket && (
+                            <Badge
+                              variant="outline"
+                              className={`text-xs py-0 px-1.5 ${BUCKET_STYLES[bucket]}`}
+                            >
+                              {BUCKET_LABELS[bucket]}
+                            </Badge>
+                          )}
+                        </div>
+                        {relationship.evidenceSnippet && (
+                          <p className="text-xs text-muted-foreground mt-1 line-clamp-2 italic">
+                            "{relationship.evidenceSnippet}"
+                          </p>
+                        )}
+                      </div>
+                      {canDelete && (
+                        <Button
+                          size="icon"
+                          variant="ghost"
+                          className="h-7 w-7 text-muted-foreground hover:text-destructive flex-shrink-0"
+                          aria-label="Remove relationship"
+                          disabled={deleteRelationshipMutation.isPending}
+                          onClick={() =>
+                            deleteRelationshipMutation.mutate(relationship.id)
+                          }
+                        >
+                          <Trash2 className="h-3.5 w-3.5" />
+                        </Button>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/notes/note-detail-sections.tsx
+++ b/client/src/components/notes/note-detail-sections.tsx
@@ -38,6 +38,8 @@ interface NoteDetailRelationship {
   evidenceSnippet: string | null;
   confidence: number | null;
   createdByUserId: string | null;
+  /** Gap F64/F89 (PRD-016): AI-enrichment edges carry a review status */
+  status?: string | null;
   fromNote: NoteDetailRelationshipEnd;
   toNote: NoteDetailRelationshipEnd;
 }
@@ -116,16 +118,25 @@ export function NoteDetailSections({
     },
   });
 
-  // PRD-048 FR-1c: group relationships by type
+  // PRD-048 FR-1c: group relationships by type.
+  // Gap F64/F89: rejected AI edges are hidden; pending ones are badged below
+  // so unreviewed suggestions are never indistinguishable from confirmed facts.
+  const visibleRelationships = useMemo(
+    () =>
+      (detail?.relationships ?? []).filter(
+        (relationship) => relationship.status !== "rejected"
+      ),
+    [detail?.relationships]
+  );
   const groupedRelationships = useMemo(() => {
     const groups = new Map<string, NoteDetailRelationship[]>();
-    for (const relationship of detail?.relationships ?? []) {
+    for (const relationship of visibleRelationships) {
       const group = groups.get(relationship.relationshipType) ?? [];
       group.push(relationship);
       groups.set(relationship.relationshipType, group);
     }
     return groups;
-  }, [detail?.relationships]);
+  }, [visibleRelationships]);
 
   if (isLoading) {
     return (
@@ -137,7 +148,7 @@ export function NoteDetailSections({
   }
 
   const referencesIn = detail?.referencesIn ?? [];
-  const relationships = detail?.relationships ?? [];
+  const relationships = visibleRelationships;
 
   return (
     <div className="space-y-4 border-t mt-4 pt-4">
@@ -262,6 +273,14 @@ export function NoteDetailSections({
                               className={`text-xs py-0 px-1.5 ${BUCKET_STYLES[bucket]}`}
                             >
                               {BUCKET_LABELS[bucket]}
+                            </Badge>
+                          )}
+                          {relationship.status === "pending" && (
+                            <Badge
+                              variant="outline"
+                              className="text-xs py-0 px-1.5 bg-amber-500/10 text-amber-600 border-amber-500/20"
+                            >
+                              Pending AI review
                             </Badge>
                           )}
                         </div>

--- a/client/src/components/notes/notes-editor-panel.tsx
+++ b/client/src/components/notes/notes-editor-panel.tsx
@@ -85,7 +85,10 @@ interface NotesEditorPanelProps {
   memberRole?: string; // PRD-048: role-gates relationship deletion
   onNoteCreated: (note: Note) => void;
   onNoteDeleted: (noteId: string) => void;
-  onOpenNote?: (noteId: string) => void;
+  onOpenNote?: (noteId: string, highlight?: { start: number; end: number }) => void;
+  // P2-2 (PRD-005 FR-3): mention offsets to scroll to + select after opening
+  pendingHighlight?: { noteId: string; start: number; end: number } | null;
+  onHighlightConsumed?: () => void;
 }
 
 export function NotesEditorPanel({
@@ -99,6 +102,8 @@ export function NotesEditorPanel({
   onNoteCreated,
   onNoteDeleted,
   onOpenNote,
+  pendingHighlight,
+  onHighlightConsumed,
 }: NotesEditorPanelProps) {
   const { toast } = useToast();
   const [draftTitle, setDraftTitle] = useState("");
@@ -115,6 +120,7 @@ export function NotesEditorPanel({
   // text before the editor switches away from it.
   const prevNoteRef = useRef<Note | null>(null);
   const draftsRef = useRef({ title: "", content: "", questStatus: "lead" as QuestStatus });
+  const contentRef = useRef<HTMLTextAreaElement | null>(null);
 
   const todayStr = format(new Date(), "yyyy-MM-dd");
 
@@ -184,6 +190,26 @@ export function NotesEditorPanel({
     setIsEditingImported(false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeNoteId, isTodayMode, todayStr]);
+
+  // P2-2 (PRD-005 FR-3): when a backlink reference opened this note with
+  // mention offsets, select the mention and scroll it into view. The text
+  // selection doubles as the highlight in a plain textarea.
+  useEffect(() => {
+    if (!pendingHighlight || pendingHighlight.noteId !== activeNoteId) return;
+    const el = contentRef.current;
+    if (!el) return;
+    const { start, end } = pendingHighlight;
+    requestAnimationFrame(() => {
+      el.focus();
+      const safeStart = Math.min(start, el.value.length);
+      const safeEnd = Math.min(Math.max(end, safeStart), el.value.length);
+      el.setSelectionRange(safeStart, safeEnd);
+      const proportion = safeStart / Math.max(1, el.value.length);
+      el.scrollTop = Math.max(0, proportion * el.scrollHeight - el.clientHeight / 2);
+    });
+    onHighlightConsumed?.();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pendingHighlight, activeNoteId, draftContent]);
 
   // Create session mutation
   const createSessionMutation = useMutation({
@@ -495,6 +521,7 @@ export function NotesEditorPanel({
                 </Label>
                 <Textarea
                   id="content"
+                  ref={contentRef}
                   value={draftContent}
                   onChange={(e) => handleContentChange(e.target.value)}
                   placeholder={

--- a/client/src/components/notes/notes-editor-panel.tsx
+++ b/client/src/components/notes/notes-editor-panel.tsx
@@ -43,6 +43,7 @@ import { QUEST_STATUSES, QUEST_STATUS_LABELS } from "@shared/schema";
 import { format } from "date-fns";
 import { EntitySuggestionsPanel } from "./entity-suggestions-panel";
 import { NoteDetailSections } from "./note-detail-sections";
+import { ImportedNoteView } from "./imported-note-view";
 
 const NOTE_TYPE_LABELS: Record<NoteType, string> = {
   area: "Area",
@@ -103,29 +104,86 @@ export function NotesEditorPanel({
   const [draftTitle, setDraftTitle] = useState("");
   const [draftContent, setDraftContent] = useState("");
   const [draftQuestStatus, setDraftQuestStatus] = useState<QuestStatus>("lead");
+  // PRD-008 FR-4 (gap F2): session date is editable independently of the title
+  const [draftSessionDate, setDraftSessionDate] = useState("");
   const [isDeleteOpen, setIsDeleteOpen] = useState(false);
   const [hasCreatedToday, setHasCreatedToday] = useState(false);
+  // Gap F47: imported notes render read-mode markdown until the user edits
+  const [isEditingImported, setIsEditingImported] = useState(false);
   const isCreatingRef = useRef(false);
+  // Gap F43: track the previous note + live drafts so we can flush unsaved
+  // text before the editor switches away from it.
+  const prevNoteRef = useRef<Note | null>(null);
+  const draftsRef = useRef({ title: "", content: "", questStatus: "lead" as QuestStatus });
 
   const todayStr = format(new Date(), "yyyy-MM-dd");
 
   // Get the active note (either selected note or today's session)
   const activeNote = isTodayMode ? todaySession : selectedNote;
 
-  // Sync draft with active note
+  // Keep a live snapshot of drafts for the flush-on-switch path
   useEffect(() => {
+    draftsRef.current = {
+      title: draftTitle,
+      content: draftContent,
+      questStatus: draftQuestStatus,
+    };
+  });
+
+  // Sync draft with active note. Keyed by note id (not object identity) so a
+  // background refetch of the notes list does not clobber in-progress typing.
+  const activeNoteId = activeNote?.id ?? null;
+  useEffect(() => {
+    // Gap F43 (PRD-019 FR-4): flush unsaved draft text for the note we are
+    // leaving before resetting the editor, so switching selection inside the
+    // debounce window never drops typed text.
+    const prev = prevNoteRef.current;
+    if (prev && prev.id !== activeNoteId) {
+      const drafts = draftsRef.current;
+      const dirty =
+        drafts.title !== prev.title ||
+        drafts.content !== (prev.content || "") ||
+        (prev.noteType === "quest" &&
+          drafts.questStatus !== (prev.questStatus || "lead"));
+      if (dirty) {
+        apiRequest("PATCH", `/api/teams/${team.id}/notes/${prev.id}`, {
+          title: drafts.title,
+          content: drafts.content,
+          ...(prev.noteType === "quest" ? { questStatus: drafts.questStatus } : {}),
+        })
+          .then(() => {
+            queryClient.invalidateQueries({
+              queryKey: ["/api/teams", team.id, "notes"],
+            });
+          })
+          .catch(() => {
+            // The autosave error indicator already covers persistent failures;
+            // a failed flush must not block switching notes.
+          });
+      }
+    }
+    prevNoteRef.current = activeNote ?? null;
+
     if (activeNote) {
       setDraftTitle(activeNote.title);
       setDraftContent(activeNote.content || "");
       setDraftQuestStatus(activeNote.questStatus || "lead");
+      setDraftSessionDate(
+        activeNote.sessionDate
+          ? format(new Date(activeNote.sessionDate), "yyyy-MM-dd")
+          : ""
+      );
       setHasCreatedToday(true);
     } else if (isTodayMode) {
       setDraftTitle(todayStr);
       setDraftContent("");
       setDraftQuestStatus("lead");
+      setDraftSessionDate("");
       setHasCreatedToday(false);
     }
-  }, [activeNote, isTodayMode, todayStr]);
+    setIsEditingImported(false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeNoteId, isTodayMode, todayStr]);
 
   // Create session mutation
   const createSessionMutation = useMutation({
@@ -217,6 +275,27 @@ export function NotesEditorPanel({
         return;
       }
 
+      // Gap F42 (PRD-019 FR-4): deleting today's session content back to empty
+      // removes the session record instead of leaving a ghost entry.
+      if (
+        isTodayMode &&
+        activeNote &&
+        activeNote.noteType === "session_log" &&
+        data.content.trim() === "" &&
+        (activeNote.content || "").trim() !== ""
+      ) {
+        await apiRequest(
+          "DELETE",
+          `/api/teams/${team.id}/notes/${activeNote.id}`
+        );
+        setHasCreatedToday(false);
+        onNoteDeleted(activeNote.id);
+        queryClient.invalidateQueries({
+          queryKey: ["/api/teams", team.id, "notes"],
+        });
+        return;
+      }
+
       // Update existing note
       if (activeNote) {
         await updateNoteMutation.mutateAsync({
@@ -234,6 +313,8 @@ export function NotesEditorPanel({
       activeNote,
       createSessionMutation,
       updateNoteMutation,
+      team.id,
+      onNoteDeleted,
     ]
   );
 
@@ -250,6 +331,27 @@ export function NotesEditorPanel({
   const handleDelete = () => {
     setIsDeleteOpen(false);
     deleteNoteMutation.mutate();
+  };
+
+  // PRD-008 FR-4 (gap F2): persist a session date change immediately
+  const handleSessionDateChange = (value: string) => {
+    setDraftSessionDate(value);
+    if (!activeNote || !value) return;
+    // Anchor at midday to avoid timezone-boundary date shifts
+    apiRequest("PATCH", `/api/teams/${team.id}/notes/${activeNote.id}`, {
+      sessionDate: new Date(`${value}T12:00:00`).toISOString(),
+    })
+      .then(() => {
+        queryClient.invalidateQueries({
+          queryKey: ["/api/teams", team.id, "notes"],
+        });
+      })
+      .catch(() => {
+        toast({
+          title: "Failed to update session date",
+          variant: "destructive",
+        });
+      });
   };
 
   // Handle content change - check for empty to potentially delete
@@ -316,16 +418,36 @@ export function NotesEditorPanel({
 
       {/* Editor content */}
       <div className="flex-1 overflow-auto p-4 space-y-4">
-        {/* Title input (for non-session notes) */}
-        {activeNote && activeNote.noteType !== "session_log" && (
-          <div className="space-y-2">
-            <Label htmlFor="title">Title</Label>
-            <Input
-              id="title"
-              value={draftTitle}
-              onChange={(e) => setDraftTitle(e.target.value)}
-              placeholder="Note title"
-            />
+        {/* Title input. PRD-008 FR-3 (gap F3): session titles are editable too,
+            e.g. "2026-07-05 - Dockside Investigation". */}
+        {activeNote && (
+          <div className="flex gap-3 flex-wrap">
+            <div className="space-y-2 flex-1 min-w-[200px]">
+              <Label htmlFor="title">Title</Label>
+              <Input
+                id="title"
+                value={draftTitle}
+                onChange={(e) => setDraftTitle(e.target.value)}
+                placeholder={
+                  activeNote.noteType === "session_log"
+                    ? "Session title"
+                    : "Note title"
+                }
+              />
+            </div>
+            {/* PRD-008 FR-4 (gap F2): editable session date, independent of title */}
+            {activeNote.noteType === "session_log" && (
+              <div className="space-y-2">
+                <Label htmlFor="session-date">Session Date</Label>
+                <Input
+                  id="session-date"
+                  type="date"
+                  value={draftSessionDate}
+                  onChange={(e) => handleSessionDateChange(e.target.value)}
+                  className="w-[160px]"
+                />
+              </div>
+            )}
           </div>
         )}
 
@@ -351,29 +473,51 @@ export function NotesEditorPanel({
           </div>
         )}
 
-        {/* Content editor */}
+        {/* Content editor. Gap F47 (PRD-015 FR-4): imported notes render their
+            link-resolved markdown read-mode by default; Edit switches to the
+            plain editor. */}
         {(isTodayMode || activeNote) && (
           <div className="space-y-2 flex-1">
-            <Label htmlFor="content">
-              {isTodayMode ? "Session Notes" : "Content"}
-            </Label>
-            <Textarea
-              id="content"
-              value={draftContent}
-              onChange={(e) => handleContentChange(e.target.value)}
-              placeholder={
-                isTodayMode || activeNote?.noteType === "session_log"
-                  ? "Start typing your session notes..."
-                  : "Add details about this entity... (appearance, role, motivations, etc.)"
-              }
-              className="min-h-[400px] resize-none"
-            />
+            {activeNote &&
+            activeNote.noteType !== "session_log" &&
+            activeNote.sourceSystem &&
+            activeNote.contentMarkdownResolved &&
+            !isEditingImported ? (
+              <ImportedNoteView
+                note={activeNote}
+                onOpenNote={onOpenNote}
+                onEdit={() => setIsEditingImported(true)}
+              />
+            ) : (
+              <>
+                <Label htmlFor="content">
+                  {isTodayMode ? "Session Notes" : "Content"}
+                </Label>
+                <Textarea
+                  id="content"
+                  value={draftContent}
+                  onChange={(e) => handleContentChange(e.target.value)}
+                  placeholder={
+                    isTodayMode || activeNote?.noteType === "session_log"
+                      ? "Start typing your session notes..."
+                      : "Add details about this entity... (appearance, role, motivations, etc.)"
+                  }
+                  className="min-h-[400px] resize-none"
+                />
+              </>
+            )}
 
             {/* Entity Suggestions Panel - only for session logs */}
             {(isTodayMode || activeNote?.noteType === "session_log") && (
               <EntitySuggestionsPanel
                 team={team}
-                sessionDate={todayStr}
+                // Gap F27: key suggestion persistence to the session's own date,
+                // not today's, so reviewing an older session keeps its own state
+                sessionDate={
+                  activeNote?.sessionDate
+                    ? format(new Date(activeNote.sessionDate), "yyyy-MM-dd")
+                    : todayStr
+                }
                 content={draftContent}
                 sessionNote={activeNote}
                 memberAiEnabled={memberAiEnabled}

--- a/client/src/components/notes/notes-editor-panel.tsx
+++ b/client/src/components/notes/notes-editor-panel.tsx
@@ -42,6 +42,7 @@ import type { Note, NoteType, Team, QuestStatus } from "@shared/schema";
 import { QUEST_STATUSES, QUEST_STATUS_LABELS } from "@shared/schema";
 import { format } from "date-fns";
 import { EntitySuggestionsPanel } from "./entity-suggestions-panel";
+import { NoteDetailSections } from "./note-detail-sections";
 
 const NOTE_TYPE_LABELS: Record<NoteType, string> = {
   area: "Area",
@@ -80,6 +81,7 @@ interface NotesEditorPanelProps {
   todaySession: Note | null;
   isTodayMode: boolean;
   memberAiEnabled: boolean; // PRD-028
+  memberRole?: string; // PRD-048: role-gates relationship deletion
   onNoteCreated: (note: Note) => void;
   onNoteDeleted: (noteId: string) => void;
   onOpenNote?: (noteId: string) => void;
@@ -92,6 +94,7 @@ export function NotesEditorPanel({
   todaySession,
   isTodayMode,
   memberAiEnabled,
+  memberRole,
   onNoteCreated,
   onNoteDeleted,
   onOpenNote,
@@ -359,9 +362,9 @@ export function NotesEditorPanel({
               value={draftContent}
               onChange={(e) => handleContentChange(e.target.value)}
               placeholder={
-                isTodayMode
+                isTodayMode || activeNote?.noteType === "session_log"
                   ? "Start typing your session notes..."
-                  : "Write your notes here..."
+                  : "Add details about this entity... (appearance, role, motivations, etc.)"
               }
               className="min-h-[400px] resize-none"
             />
@@ -378,6 +381,19 @@ export function NotesEditorPanel({
                 onOpenNote={onOpenNote}
               />
             )}
+
+            {/* PRD-048: entity pages show session references + relationships */}
+            {!isTodayMode &&
+              activeNote &&
+              activeNote.noteType !== "session_log" && (
+                <NoteDetailSections
+                  team={team}
+                  note={activeNote}
+                  userId={userId}
+                  isDm={memberRole === "dm"}
+                  onOpenNote={onOpenNote}
+                />
+              )}
           </div>
         )}
 

--- a/client/src/components/notes/notes-item-preview.tsx
+++ b/client/src/components/notes/notes-item-preview.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/components/ui/select";
 import { queryClient, apiRequest } from "@/lib/queryClient";
 import type { Note, NoteType, Team } from "@shared/schema";
+import { QUEST_STATUS_LABELS, QUEST_STATUS_COLORS } from "@shared/schema";
 import { NOTE_TYPES } from "@shared/schema";
 import { formatDistanceToNow } from "date-fns";
 
@@ -93,6 +94,15 @@ export function NotesItemPreview({
             >
               {NOTE_TYPE_LABELS[note.noteType]}
             </Badge>
+            {/* P2-1 (PRD-004 FR-5): quest status visible in the hover preview */}
+            {note.noteType === "quest" && (
+              <Badge
+                variant="secondary"
+                className={`shrink-0 text-xs ${QUEST_STATUS_COLORS[note.questStatus || "lead"]}`}
+              >
+                {QUEST_STATUS_LABELS[note.questStatus || "lead"]}
+              </Badge>
+            )}
           </div>
 
           {contentSnippet && (

--- a/client/src/components/notes/notes-left-panel.tsx
+++ b/client/src/components/notes/notes-left-panel.tsx
@@ -29,11 +29,13 @@ import {
   ChevronDown,
   ChevronRight,
   Check,
+  CheckCircle2,
   X,
   ArrowRight,
   MoreHorizontal,
 } from "lucide-react";
-import type { Note, NoteType, Team } from "@shared/schema";
+import type { Note, NoteType, QuestStatus, Team } from "@shared/schema";
+import { QUEST_STATUSES, QUEST_STATUS_LABELS, QUEST_STATUS_COLORS } from "@shared/schema";
 import { format } from "date-fns";
 import { cn } from "@/lib/utils";
 
@@ -174,6 +176,8 @@ export function NotesLeftPanel({
   const [expandedSections, setExpandedSections] = useState<string[]>([
     "sessions",
   ]);
+  // P2-1 (PRD-004 FR-5, gap F32): filter quests by lifecycle status
+  const [questStatusFilter, setQuestStatusFilter] = useState<QuestStatus | "all">("all");
   // PRD-037: State for needs review section
   const [isNeedsReviewExpanded, setIsNeedsReviewExpanded] = useState(true);
   // PRD-038: State for expanded review item
@@ -431,7 +435,14 @@ export function NotesLeftPanel({
           className="px-2"
         >
           {FILTER_CATEGORIES.map((category) => {
-            const categoryNotes = notesByCategory[category.key] || [];
+            const allCategoryNotes = notesByCategory[category.key] || [];
+            // P2-1: quests can be narrowed to a single lifecycle status
+            const categoryNotes =
+              category.key === "quests" && questStatusFilter !== "all"
+                ? allCategoryNotes.filter(
+                    (note) => (note.questStatus || "lead") === questStatusFilter
+                  )
+                : allCategoryNotes;
             const Icon = category.icon;
 
             return (
@@ -445,11 +456,33 @@ export function NotesLeftPanel({
                     <Icon className={cn("h-4 w-4", category.color)} />
                     <span className="text-sm">{category.label}</span>
                     <Badge variant="secondary" className="ml-1 h-5 px-1.5">
-                      {categoryNotes.length}
+                      {allCategoryNotes.length}
                     </Badge>
                   </div>
                 </AccordionTrigger>
                 <AccordionContent className="pb-2">
+                  {category.key === "quests" && allCategoryNotes.length > 0 && (
+                    <div
+                      className="flex flex-wrap gap-1 px-2 pb-2"
+                      data-testid="quest-status-filter"
+                    >
+                      {(["all", ...QUEST_STATUSES] as const).map((status) => (
+                        <button
+                          key={status}
+                          type="button"
+                          onClick={() => setQuestStatusFilter(status)}
+                          className={cn(
+                            "text-xs px-2 py-0.5 rounded-full border transition-colors",
+                            questStatusFilter === status
+                              ? "bg-primary text-primary-foreground border-primary"
+                              : "bg-transparent text-muted-foreground hover:bg-accent"
+                          )}
+                        >
+                          {status === "all" ? "All" : QUEST_STATUS_LABELS[status]}
+                        </button>
+                      ))}
+                    </div>
+                  )}
                   {categoryNotes.length === 0 ? (
                     <p className="text-xs text-muted-foreground pl-6 py-2">
                       No items
@@ -479,6 +512,25 @@ export function NotesLeftPanel({
                                 </span>
                               ) : null}
                               <span className="truncate">{note.title}</span>
+                              {/* P2-1 (PRD-004 FR-5): quest lifecycle at a glance */}
+                              {note.noteType === "quest" && (
+                                <Badge
+                                  variant="secondary"
+                                  className={cn(
+                                    "text-xs py-0 px-1.5 flex-shrink-0",
+                                    QUEST_STATUS_COLORS[note.questStatus || "lead"]
+                                  )}
+                                >
+                                  {QUEST_STATUS_LABELS[note.questStatus || "lead"]}
+                                </Badge>
+                              )}
+                              {/* PRD-003 FR-5 (gap F19): reviewed sessions are marked */}
+                              {note.noteType === "session_log" && note.reviewedAt && (
+                                <CheckCircle2
+                                  className="h-3.5 w-3.5 text-green-500 flex-shrink-0"
+                                  aria-label="Session reviewed"
+                                />
+                              )}
                             </div>
                           </button>
                         </NotesItemPreview>

--- a/client/src/components/notes/quest-promotion-section.tsx
+++ b/client/src/components/notes/quest-promotion-section.tsx
@@ -1,0 +1,122 @@
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { ScrollText, Plus, Link2, X, Loader2, Check } from "lucide-react";
+import type { CleanupQuestSuggestion } from "@shared/cleanup-suggestions";
+
+export type QuestSuggestionStatus = "pending" | "promoted" | "dismissed";
+
+interface QuestPromotionSectionProps {
+  suggestions: CleanupQuestSuggestion[];
+  statusById: Map<string, QuestSuggestionStatus>;
+  pendingId?: string | null;
+  onCreateQuest: (suggestion: CleanupQuestSuggestion) => void;
+  onLinkExistingQuest: (
+    suggestion: CleanupQuestSuggestion,
+    questNoteId: string
+  ) => void;
+  onDismiss: (suggestion: CleanupQuestSuggestion) => void;
+}
+
+/**
+ * PRD-049 FR-3: "Promote to Quest" suggestions generated from actionable text
+ * (Find/Defeat/Retrieve ...). Users can create a new quest, link an existing
+ * one, or dismiss.
+ */
+export function QuestPromotionSection({
+  suggestions,
+  statusById,
+  pendingId,
+  onCreateQuest,
+  onLinkExistingQuest,
+  onDismiss,
+}: QuestPromotionSectionProps) {
+  const visible = suggestions.filter(
+    (s) => statusById.get(s.id) !== "dismissed"
+  );
+
+  if (visible.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-2" data-testid="quest-promotion-section">
+      <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+        Quest Promotion
+      </h4>
+      <div className="space-y-2">
+        {visible.map((suggestion) => {
+          const status = statusById.get(suggestion.id) || "pending";
+          const isPromoted = status === "promoted";
+          const isPending = pendingId === suggestion.id;
+
+          return (
+            <div
+              key={suggestion.id}
+              className="p-3 rounded-lg border border-red-500/20 bg-red-500/5"
+              data-testid={`quest-suggestion-${suggestion.id}`}
+            >
+              <div className="flex items-center gap-2">
+                <ScrollText className="h-4 w-4 text-red-500 flex-shrink-0" />
+                <span className="text-sm font-medium truncate">
+                  {suggestion.proposedQuestTitle}
+                </span>
+                <Badge variant="secondary" className="text-xs py-0 px-1.5">
+                  Quest
+                </Badge>
+              </div>
+              <p className="mt-2 text-xs text-muted-foreground italic line-clamp-2">
+                "{suggestion.snippetText}"
+              </p>
+              <div className="flex gap-2 mt-2 flex-wrap">
+                {isPromoted ? (
+                  <Badge variant="secondary" className="text-xs">
+                    <Check className="h-3 w-3 mr-1" />
+                    Promoted
+                  </Badge>
+                ) : (
+                  <>
+                    <Button
+                      size="sm"
+                      variant="default"
+                      className="h-7 text-xs"
+                      disabled={isPending}
+                      onClick={() => onCreateQuest(suggestion)}
+                    >
+                      {isPending ? (
+                        <Loader2 className="h-3 w-3 mr-1 animate-spin" />
+                      ) : (
+                        <Plus className="h-3 w-3 mr-1" />
+                      )}
+                      Create Quest
+                    </Button>
+                    {suggestion.existingQuestMatches.map((quest) => (
+                      <Button
+                        key={quest.id}
+                        size="sm"
+                        variant="outline"
+                        className="h-7 text-xs"
+                        disabled={isPending}
+                        onClick={() => onLinkExistingQuest(suggestion, quest.id)}
+                      >
+                        <Link2 className="h-3 w-3 mr-1" />
+                        Link "{quest.title}"
+                      </Button>
+                    ))}
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      className="h-7 text-xs px-2"
+                      onClick={() => onDismiss(suggestion)}
+                    >
+                      <X className="h-3 w-3" />
+                    </Button>
+                  </>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/notes/relationship-suggestions-section.tsx
+++ b/client/src/components/notes/relationship-suggestions-section.tsx
@@ -1,0 +1,152 @@
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Check, X, Loader2 } from "lucide-react";
+import type { CleanupRelationshipSuggestion, ConfidenceBucket } from "@shared/cleanup-suggestions";
+
+const BUCKET_STYLES: Record<ConfidenceBucket, string> = {
+  HIGH: "bg-green-500/10 text-green-600 border-green-500/20",
+  REVIEW: "bg-amber-500/10 text-amber-600 border-amber-500/20",
+  LOW: "bg-gray-500/10 text-gray-500 border-gray-500/20",
+};
+
+const BUCKET_LABELS: Record<ConfidenceBucket, string> = {
+  HIGH: "High",
+  REVIEW: "Needs review",
+  LOW: "Low",
+};
+
+const RELATIONSHIP_TYPE_LABELS: Record<string, string> = {
+  QuestHasNPC: "Quest → NPC",
+  QuestAtPlace: "Quest → Place",
+  NPCInPlace: "NPC → Place",
+  Related: "Related",
+};
+
+export type RelationshipSuggestionStatus = "pending" | "accepted" | "dismissed";
+
+interface RelationshipSuggestionsSectionProps {
+  suggestions: CleanupRelationshipSuggestion[];
+  statusById: Map<string, RelationshipSuggestionStatus>;
+  pendingId?: string | null;
+  onAccept: (suggestion: CleanupRelationshipSuggestion) => void;
+  onDismiss: (suggestion: CleanupRelationshipSuggestion) => void;
+}
+
+/**
+ * PRD-049 FR-1: relationship suggestions surfaced in the AI Cleanup panel with
+ * Accept/Dismiss actions and visible evidence + confidence buckets.
+ */
+export function RelationshipSuggestionsSection({
+  suggestions,
+  statusById,
+  pendingId,
+  onAccept,
+  onDismiss,
+}: RelationshipSuggestionsSectionProps) {
+  const visible = suggestions.filter(
+    (s) => statusById.get(s.id) !== "dismissed"
+  );
+
+  if (visible.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-2" data-testid="relationship-suggestions-section">
+      <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+        Relationship Suggestions
+      </h4>
+      <div className="space-y-2">
+        {visible.map((suggestion) => {
+          const status = statusById.get(suggestion.id) || "pending";
+          const isAccepted = status === "accepted";
+          const isPending = pendingId === suggestion.id;
+          // LOW-confidence suggestions are visually de-emphasized (PRD-049 FR-5)
+          const deEmphasized = suggestion.confidenceBucket === "LOW";
+
+          return (
+            <div
+              key={suggestion.id}
+              className={`p-3 rounded-lg border ${deEmphasized ? "opacity-60" : ""}`}
+              data-testid={`relationship-suggestion-${suggestion.id}`}
+            >
+              <div className="flex items-center justify-between gap-2 flex-wrap">
+                <div className="flex items-center gap-2 min-w-0 flex-wrap">
+                  <span className="text-sm font-medium">
+                    {suggestion.fromEntityText}
+                  </span>
+                  <span className="text-muted-foreground text-xs">→</span>
+                  <span className="text-sm font-medium">
+                    {suggestion.toEntityText}
+                  </span>
+                  <Badge variant="secondary" className="text-xs py-0 px-1.5">
+                    {RELATIONSHIP_TYPE_LABELS[suggestion.relationshipType] ||
+                      suggestion.relationshipType}
+                  </Badge>
+                  <Badge variant="outline" className="text-xs py-0 px-1.5">
+                    {suggestion.evidenceType}
+                  </Badge>
+                  <Badge
+                    variant="outline"
+                    className={`text-xs py-0 px-1.5 ${BUCKET_STYLES[suggestion.confidenceBucket]}`}
+                  >
+                    {BUCKET_LABELS[suggestion.confidenceBucket]} (
+                    {Math.round(suggestion.confidence * 100)}%)
+                  </Badge>
+                </div>
+                <div className="flex gap-1">
+                  {isAccepted ? (
+                    <Badge variant="secondary" className="text-xs">
+                      <Check className="h-3 w-3 mr-1" />
+                      Accepted
+                    </Badge>
+                  ) : (
+                    <>
+                      <Button
+                        size="sm"
+                        variant="default"
+                        className="h-7 text-xs"
+                        disabled={suggestion.requiresResolution || isPending}
+                        title={
+                          suggestion.requiresResolution
+                            ? "Both entities must be linked to existing notes first"
+                            : undefined
+                        }
+                        onClick={() => onAccept(suggestion)}
+                      >
+                        {isPending ? (
+                          <Loader2 className="h-3 w-3 mr-1 animate-spin" />
+                        ) : (
+                          <Check className="h-3 w-3 mr-1" />
+                        )}
+                        Accept
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        className="h-7 text-xs px-2"
+                        onClick={() => onDismiss(suggestion)}
+                      >
+                        <X className="h-3 w-3" />
+                      </Button>
+                    </>
+                  )}
+                </div>
+              </div>
+              {suggestion.snippetText && (
+                <p className="mt-2 text-xs text-muted-foreground italic line-clamp-2">
+                  "{suggestion.snippetText}"
+                </p>
+              )}
+              {suggestion.requiresResolution && !isAccepted && (
+                <p className="mt-1 text-xs text-amber-600">
+                  Link both entities to existing notes to enable Accept.
+                </p>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/nuclino-import-dialog.tsx
+++ b/client/src/components/nuclino-import-dialog.tsx
@@ -398,8 +398,30 @@ export function NuclinoImportDialog({
       });
     },
     onError: (error: Error) => {
-      setErrorMessage(error.message);
       setCurrentOperationId(null); // PRD-035: Stop polling on error
+
+      // P2-4 F66: the 5-minute AI preview cache expired between preview and
+      // confirm. Instead of dead-ending on an error screen, transparently
+      // re-run the AI analysis so the user lands on a fresh diff preview.
+      if (error.message.includes("AI preview not found or expired") && parseResult) {
+        toast({
+          title: "AI preview expired",
+          description: "Re-running AI analysis to generate a fresh preview...",
+        });
+        setAiPreviewResult(null);
+        setAiPreviewError(null);
+        const opId = generateOperationId();
+        setCurrentOperationId(opId);
+        setState("ai-diff-loading");
+        aiPreviewMutation.mutate({
+          importPlanId: parseResult.importPlanId,
+          operationId: opId,
+          aiOptions: pcNames.length > 0 ? { playerCharacterNames: pcNames } : undefined,
+        });
+        return;
+      }
+
+      setErrorMessage(error.message);
       setState("error");
     },
   });

--- a/client/src/components/nuclino-import-dialog.tsx
+++ b/client/src/components/nuclino-import-dialog.tsx
@@ -78,6 +78,10 @@ interface ParseResponse {
     totalLinks: number;
     pagesWithLinks: number;
     uniqueTargetPages: number;
+    // PRD-050 FR-5: link resolution stats
+    resolvedLinks?: number;
+    unresolvedLinks?: number;
+    topUnresolvedTargets?: Array<{ target: string; count: number }>;
   };
   pages: ParsedPage[];
   detectedPCNames?: string[]; // PRD-040: PC names from team member settings
@@ -633,9 +637,32 @@ export function NuclinoImportDialog({
               <>
                 <span>·</span>
                 <span>{linkStats.totalLinks} links ({linkStats.uniqueTargetPages} unique targets)</span>
+                {typeof linkStats.resolvedLinks === "number" && (
+                  <>
+                    <span>·</span>
+                    <span data-testid="link-resolution-stats">
+                      {linkStats.resolvedLinks} resolved / {linkStats.unresolvedLinks ?? 0} unresolved
+                    </span>
+                  </>
+                )}
               </>
             )}
           </div>
+
+          {/* PRD-050 FR-5: surface unresolved link targets so users can decide whether to proceed */}
+          {linkStats?.topUnresolvedTargets && linkStats.topUnresolvedTargets.length > 0 && (
+            <div className="rounded-lg border border-amber-500/40 bg-amber-500/10 p-3 text-sm">
+              <p className="font-medium mb-1">Unresolved link targets</p>
+              <ul className="text-xs text-muted-foreground space-y-0.5">
+                {linkStats.topUnresolvedTargets.map(({ target, count }) => (
+                  <li key={target} className="truncate">
+                    {target}
+                    {count > 1 ? ` (×${count})` : ""}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
 
           {/* PRD-042: Expandable empty pages section */}
           {emptyPages.length > 0 && (

--- a/client/src/hooks/use-suggestion-persistence.ts
+++ b/client/src/hooks/use-suggestion-persistence.ts
@@ -23,6 +23,7 @@ interface UseSuggestionPersistenceResult {
   dismissEntity: (entityId: string) => void;
   reclassifyEntity: (entityId: string, newType: NoteType) => void;
   markCreated: (entityId: string) => void;
+  unmarkCreated: (entityId: string) => void;
   isDismissed: (entityId: string) => boolean;
   getReclassifiedType: (entityId: string) => NoteType | undefined;
   isCreated: (entityId: string) => boolean;
@@ -155,6 +156,15 @@ export function useSuggestionPersistence({
     setCreated(prev => new Set([...prev, entityId]));
   }, []);
 
+  // PRD-047 FR-3: undoing a link reverts the entity to actionable state
+  const unmarkCreated = useCallback((entityId: string) => {
+    setCreated(prev => {
+      const next = new Set(prev);
+      next.delete(entityId);
+      return next;
+    });
+  }, []);
+
   const isDismissed = useCallback((entityId: string) => {
     return dismissed.has(entityId);
   }, [dismissed]);
@@ -185,6 +195,7 @@ export function useSuggestionPersistence({
     dismissEntity,
     reclassifyEntity,
     markCreated,
+    unmarkCreated,
     isDismissed,
     getReclassifiedType,
     isCreated,

--- a/client/src/hooks/use-suggestion-persistence.ts
+++ b/client/src/hooks/use-suggestion-persistence.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { format } from "date-fns";
 import type { NoteType } from "@shared/schema";
 
@@ -137,8 +137,29 @@ export function useSuggestionPersistence({
     }
   }, [enabled, teamId, currentDate]);
 
+  // Reload state when the storage key changes (e.g. the user opens a different
+  // session's editor, or the session log finishes loading and supplies its own
+  // date). Without this the state captured at mount would be written to the new
+  // key. Declared before the persist effect; skipPersistRef prevents the persist
+  // effect from writing pre-reload state to the new key in the same commit.
+  const initializedKeyRef = useRef(storageKey);
+  const skipPersistRef = useRef(false);
+  useEffect(() => {
+    if (initializedKeyRef.current === storageKey) return;
+    initializedKeyRef.current = storageKey;
+    skipPersistRef.current = true;
+    const stored = enabled ? loadState(storageKey) : null;
+    setDismissed(stored ? new Set(stored.dismissed) : new Set());
+    setReclassified(stored ? new Map(stored.reclassified) : new Map());
+    setCreated(stored ? new Set(stored.created) : new Set());
+  }, [storageKey, enabled]);
+
   // Persist state changes
   useEffect(() => {
+    if (skipPersistRef.current) {
+      skipPersistRef.current = false;
+      return;
+    }
     if (enabled && teamId) {
       saveState(storageKey, { dismissed, reclassified, created });
     }

--- a/client/src/pages/join-team.tsx
+++ b/client/src/pages/join-team.tsx
@@ -80,7 +80,7 @@ export default function JoinTeamPage() {
         <CardHeader className="text-center">
           <div className="flex items-center justify-center gap-2 mb-4">
             <Dices className="h-8 w-8 text-primary" />
-            <span className="text-xl font-medium">Quest Keeper</span>
+            <span className="text-xl font-medium">Helm</span>
           </div>
           {status === "success" ? (
             <>

--- a/client/src/pages/notes.test.tsx
+++ b/client/src/pages/notes.test.tsx
@@ -392,6 +392,37 @@ describe('NotesPage - Two-Panel Layout (PRD-019)', () => {
   });
 
   // P1-1 (PRD-008 FR-3/FR-4): session title and date are editable
+  // P2-1 (PRD-004 FR-5): quest status badges + filter in the quest list
+  describe('Quest Status in Lists (PRD-004 FR-5)', () => {
+    it('shows a status badge on quest rows', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<NotesPage team={mockTeam} />);
+
+      await user.click(screen.getByText('Quests'));
+      const questTitle = await screen.findByText('Find the Missing Artifact');
+      // note-3 fixture has questStatus 'active' — badge rendered inside the row
+      const row = questTitle.closest('button');
+      expect(within(row!).getByText('Active')).toBeInTheDocument();
+    });
+
+    it('filters quests by status via the chips', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<NotesPage team={mockTeam} />);
+
+      await user.click(screen.getByText('Quests'));
+      await screen.findByTestId('quest-status-filter');
+
+      // Filter to a status with no quests
+      await user.click(screen.getByRole('button', { name: 'Done' }));
+      expect(screen.queryByText('Find the Missing Artifact')).not.toBeInTheDocument();
+      expect(screen.getByText('No items')).toBeInTheDocument();
+
+      // Back to All restores the quest
+      await user.click(screen.getByRole('button', { name: 'All' }));
+      expect(await screen.findByText('Find the Missing Artifact')).toBeInTheDocument();
+    });
+  });
+
   describe('Session Title and Date Editing (PRD-008)', () => {
     it('shows an editable title input and session date field for a selected session log', async () => {
       const user = userEvent.setup();

--- a/client/src/pages/notes.test.tsx
+++ b/client/src/pages/notes.test.tsx
@@ -3,7 +3,7 @@
  */
 import '@testing-library/jest-dom';
 import { describe, it, expect, vi, beforeEach, beforeAll, afterAll } from 'vitest';
-import { render, screen, within, waitFor } from '@testing-library/react';
+import { render, screen, within, waitFor, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import NotesPage from './notes';
@@ -39,6 +39,8 @@ vi.mock('@/components/ui/resizable', () => ({
 vi.mock('wouter', () => ({
   useLocation: () => ['/', vi.fn()],
   useSearch: () => '',
+  // F47 deep-link support reads /notes/:id; default to no match in tests
+  useRoute: () => [false, null],
 }));
 
 // Mock toast hook
@@ -386,6 +388,76 @@ describe('NotesPage - Two-Panel Layout (PRD-019)', () => {
           })
         );
       }, { timeout: 2000 });
+    });
+  });
+
+  // P1-1 (PRD-008 FR-3/FR-4): session title and date are editable
+  describe('Session Title and Date Editing (PRD-008)', () => {
+    it('shows an editable title input and session date field for a selected session log', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<NotesPage team={mockTeam} />);
+
+      await user.click(await screen.findByText('2024-01-15 — The Beginning'));
+
+      await waitFor(() => {
+        const titleInput = screen.getByLabelText('Title') as HTMLInputElement;
+        expect(titleInput).toBeInTheDocument();
+        expect(titleInput.value).toBe('2024-01-15 — The Beginning');
+      });
+
+      const dateInput = screen.getByLabelText('Session Date') as HTMLInputElement;
+      expect(dateInput).toBeInTheDocument();
+      expect(dateInput.value).toBe('2024-01-15');
+    });
+
+    it('persists a session date change via PATCH', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<NotesPage team={mockTeam} />);
+
+      await user.click(await screen.findByText('2024-01-15 — The Beginning'));
+
+      const dateInput = await screen.findByLabelText('Session Date');
+      fireEvent.change(dateInput, { target: { value: '2024-01-10' } });
+
+      await waitFor(() => {
+        expect(mockApiRequest).toHaveBeenCalledWith(
+          'PATCH',
+          '/api/teams/team-1/notes/note-1',
+          expect.objectContaining({
+            sessionDate: expect.stringContaining('2024-01-10'),
+          })
+        );
+      });
+    });
+  });
+
+  // P1-6 (gap F43): switching notes flushes the unsaved draft for the note
+  // being left instead of silently dropping it.
+  describe('Draft Flush on Note Switch (PRD-019 FR-4)', () => {
+    it('PATCHes the previous note with its unsaved draft when switching selection', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<NotesPage team={mockTeam} />);
+
+      // Open the session note and type into it
+      await user.click(await screen.findByText('2024-01-15 — The Beginning'));
+      const textarea = await screen.findByLabelText('Content');
+      fireEvent.change(textarea, {
+        target: { value: 'Our adventure begins... and continues!' },
+      });
+
+      // Immediately switch to another note (inside the debounce window)
+      await user.click(screen.getByText('Areas'));
+      await user.click(screen.getByText('Tavern of the Rusty Blade'));
+
+      await waitFor(() => {
+        expect(mockApiRequest).toHaveBeenCalledWith(
+          'PATCH',
+          '/api/teams/team-1/notes/note-1',
+          expect.objectContaining({
+            content: 'Our adventure begins... and continues!',
+          })
+        );
+      });
     });
   });
 

--- a/client/src/pages/notes.tsx
+++ b/client/src/pages/notes.tsx
@@ -1,4 +1,5 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
+import { useRoute } from "wouter";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { apiRequest } from "@/lib/queryClient";
 import { Button } from "@/components/ui/button";
@@ -26,6 +27,17 @@ export default function NotesPage({ team }: NotesPageProps) {
   const [selectedNoteId, setSelectedNoteId] = useState<string | null>(null);
   const [isTodayMode, setIsTodayMode] = useState(true);
   const [isImportOpen, setIsImportOpen] = useState(false);
+
+  // Gap F47 (PRD-015 FR-4): honor /notes/:id deep links (imported wiki links,
+  // browser history) by selecting the target note instead of ignoring the param.
+  const [matchesNoteRoute, noteRouteParams] = useRoute("/notes/:id");
+  const routeNoteId = matchesNoteRoute ? noteRouteParams?.id : undefined;
+  useEffect(() => {
+    if (routeNoteId) {
+      setSelectedNoteId(routeNoteId);
+      setIsTodayMode(false);
+    }
+  }, [routeNoteId]);
 
   const { data: notes, isLoading } = useQuery<Note[]>({
     queryKey: ["/api/teams", team.id, "notes"],

--- a/client/src/pages/notes.tsx
+++ b/client/src/pages/notes.tsx
@@ -216,6 +216,7 @@ export default function NotesPage({ team }: NotesPageProps) {
             todaySession={todaySession}
             isTodayMode={isTodayMode}
             memberAiEnabled={currentMember?.aiEnabled ?? false}
+            memberRole={currentMember?.role}
             onNoteCreated={handleNoteCreated}
             onNoteDeleted={handleNoteDeleted}
             onOpenNote={handleOpenNote}

--- a/client/src/pages/notes.tsx
+++ b/client/src/pages/notes.tsx
@@ -154,9 +154,21 @@ export default function NotesPage({ team }: NotesPageProps) {
     }
   };
 
-  const handleOpenNote = (noteId: string) => {
+  // P2-2 (PRD-005 FR-3): carry mention offsets so the editor can scroll to
+  // and select the exact reference after opening the note.
+  const [pendingHighlight, setPendingHighlight] = useState<{
+    noteId: string;
+    start: number;
+    end: number;
+  } | null>(null);
+
+  const handleOpenNote = (
+    noteId: string,
+    highlight?: { start: number; end: number }
+  ) => {
     setSelectedNoteId(noteId);
     setIsTodayMode(false);
+    setPendingHighlight(highlight ? { noteId, ...highlight } : null);
   };
 
   if (isLoading) {
@@ -232,6 +244,8 @@ export default function NotesPage({ team }: NotesPageProps) {
             onNoteCreated={handleNoteCreated}
             onNoteDeleted={handleNoteDeleted}
             onOpenNote={handleOpenNote}
+            pendingHighlight={pendingHighlight}
+            onHighlightConsumed={() => setPendingHighlight(null)}
           />
         </ResizablePanel>
       </ResizablePanelGroup>

--- a/client/src/pages/session-review.test.tsx
+++ b/client/src/pages/session-review.test.tsx
@@ -1,0 +1,420 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Session Review page tests (P2-5 / PRD-003):
+ * - F19: Mark as Reviewed button + reviewed state (FR-5)
+ * - F29: completion/progress semantics with matched entities
+ * - F20: selection-created entities get backlinked to the session (FR-4)
+ */
+import '@testing-library/jest-dom';
+import { describe, it, expect, vi, beforeEach, beforeAll, afterAll } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import SessionReviewPage from './session-review';
+import type { DetectedEntity } from '@shared/entity-detection';
+
+// Mock ResizeObserver for jsdom
+class MockResizeObserver {
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+}
+
+beforeAll(() => {
+  vi.stubGlobal('ResizeObserver', MockResizeObserver);
+});
+
+afterAll(() => {
+  vi.unstubAllGlobals();
+});
+
+// Mock ResizablePanelGroup to avoid jsdom issues with resize observers
+vi.mock('@/components/ui/resizable', () => ({
+  ResizablePanelGroup: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="resizable-panel-group">{children}</div>
+  ),
+  ResizablePanel: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="resizable-panel">{children}</div>
+  ),
+  ResizableHandle: () => <div data-testid="resizable-handle" />,
+}));
+
+// Mock wouter — page reads :noteId and navigates
+vi.mock('wouter', () => ({
+  useParams: () => ({ noteId: 'session-1' }),
+  useLocation: () => ['/', vi.fn()],
+}));
+
+// Mock toast hook
+const mockToast = vi.fn();
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({
+    toast: (...args: unknown[]) => mockToast(...args),
+  }),
+}));
+
+// Mock queryClient module
+const mockApiRequest = vi.fn();
+vi.mock('@/lib/queryClient', () => ({
+  queryClient: new QueryClient(),
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+}));
+
+// Mock entity detection hook (Web Worker unavailable in jsdom); tests set
+// mockEntities before rendering.
+let mockEntities: DetectedEntity[] = [];
+vi.mock('@/hooks/use-entity-detection', () => ({
+  useEntityDetection: () => ({
+    entities: mockEntities,
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+// Mock suggestion persistence hook with controllable sets
+let mockCreated = new Set<string>();
+let mockDismissed = new Set<string>();
+const mockMarkCreated = vi.fn();
+const mockDismissEntity = vi.fn();
+vi.mock('@/hooks/use-suggestion-persistence', () => ({
+  useSuggestionPersistence: () => ({
+    dismissed: mockDismissed,
+    reclassified: new Map(),
+    created: mockCreated,
+    dismissEntity: (id: string) => mockDismissEntity(id),
+    reclassifyEntity: vi.fn(),
+    markCreated: (id: string) => mockMarkCreated(id),
+    unmarkCreated: vi.fn(),
+    isDismissed: (id: string) => mockDismissed.has(id),
+    getReclassifiedType: () => undefined,
+    isCreated: (id: string) => mockCreated.has(id),
+    clearSession: vi.fn(),
+  }),
+}));
+
+// Mock SelectableContent: real component depends on window.getSelection,
+// which jsdom doesn't support meaningfully. The mock renders children plus a
+// trigger that simulates the user selecting "Lord Vex" and picking NPC.
+vi.mock('@/components/selectable-content', () => ({
+  SelectableContent: ({
+    children,
+    onCreateEntity,
+  }: {
+    children: React.ReactNode;
+    onCreateEntity: (text: string, type: string) => void;
+  }) => (
+    <div data-testid="selectable-content">
+      {children}
+      <button onClick={() => onCreateEntity('Lord Vex', 'npc')}>
+        simulate-selection
+      </button>
+    </div>
+  ),
+}));
+
+const mockTeam = {
+  id: 'team-1',
+  name: 'Test Team',
+  teamType: 'dnd' as const,
+  diceMode: 'polyhedral' as const,
+  ownerId: 'user-1',
+  inviteCode: 'ABC123',
+  createdAt: new Date(),
+  recurrenceFrequency: null,
+  dayOfWeek: null,
+  daysOfMonth: null,
+  startTime: null,
+  endTime: null,
+  timezone: null,
+  availabilityStartDate: null,
+  availabilityEndDate: null,
+  recurrenceAnchorDate: null,
+  minAttendanceThreshold: null,
+  defaultSessionDurationMinutes: null,
+  aiEnabled: false,
+  aiEnabledAt: null,
+};
+
+const baseSessionLog = {
+  id: 'session-1',
+  teamId: 'team-1',
+  authorId: 'user-1',
+  title: 'Session 5 — Into the Depths',
+  content: 'We met Lord Vex at the tavern.',
+  contentBlocks: null,
+  noteType: 'session_log',
+  isPrivate: false,
+  sessionDate: '2026-07-01T00:00:00.000Z',
+  reviewedAt: null as string | null,
+  createdAt: '2026-07-01T12:00:00.000Z',
+  updatedAt: '2026-07-01T12:00:00.000Z',
+};
+
+const existingNotes = [
+  {
+    id: 'note-gandalf',
+    teamId: 'team-1',
+    authorId: 'user-1',
+    title: 'Gandalf the Grey',
+    content: 'A wizard.',
+    noteType: 'npc',
+    isPrivate: false,
+    sessionDate: null,
+    createdAt: '2026-06-01T12:00:00.000Z',
+    updatedAt: '2026-06-01T12:00:00.000Z',
+  },
+];
+
+function makeEntity(overrides: Partial<DetectedEntity>): DetectedEntity {
+  return {
+    id: 'entity-1',
+    type: 'npc',
+    text: 'Captain Renn',
+    normalizedText: 'captain renn',
+    confidence: 'high',
+    frequency: 1,
+    mentions: [{ startOffset: 0, endOffset: 12, text: 'Captain Renn' }],
+    ...overrides,
+  };
+}
+
+function renderPage(sessionOverrides: Partial<typeof baseSessionLog> = {}) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: Infinity },
+      mutations: { retry: false },
+    },
+  });
+
+  const sessionLog = { ...baseSessionLog, ...sessionOverrides };
+  queryClient.setQueryData(
+    ['/api/teams', 'team-1', 'notes', 'session-1'],
+    sessionLog
+  );
+  queryClient.setQueryData(
+    ['/api/teams', 'team-1', 'notes'],
+    [sessionLog, ...existingNotes]
+  );
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <SessionReviewPage team={mockTeam} />
+    </QueryClientProvider>
+  );
+}
+
+describe('SessionReviewPage (P2-5)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEntities = [];
+    mockCreated = new Set();
+    mockDismissed = new Set();
+    mockApiRequest.mockResolvedValue({
+      json: () =>
+        Promise.resolve({ id: 'new-note-1', title: 'Lord Vex', noteType: 'npc' }),
+    });
+  });
+
+  // F19 (PRD-003 FR-5): mark session as reviewed
+  describe('Mark as Reviewed (F19)', () => {
+    it('shows a Mark as Reviewed button that PATCHes reviewedAt = now', async () => {
+      const user = userEvent.setup();
+      renderPage();
+
+      const button = screen.getByRole('button', { name: /mark as reviewed/i });
+      await user.click(button);
+
+      await waitFor(() => {
+        expect(mockApiRequest).toHaveBeenCalledWith(
+          'PATCH',
+          '/api/teams/team-1/notes/session-1',
+          expect.objectContaining({ reviewedAt: expect.any(String) })
+        );
+      });
+      // Payload is a valid ISO timestamp
+      const patchCall = mockApiRequest.mock.calls.find(
+        (call) => call[0] === 'PATCH'
+      );
+      const sent = (patchCall![2] as { reviewedAt: string }).reviewedAt;
+      expect(Number.isNaN(new Date(sent).getTime())).toBe(false);
+
+      await waitFor(() => {
+        expect(mockToast).toHaveBeenCalledWith(
+          expect.objectContaining({ title: 'Session marked as reviewed' })
+        );
+      });
+    });
+
+    it('renders the reviewed state with a Reviewed indicator and un-marks via PATCH null', async () => {
+      const user = userEvent.setup();
+      renderPage({ reviewedAt: '2026-07-05T10:00:00.000Z' });
+
+      // Indicator near the session title
+      expect(screen.getByText(/Reviewed Jul 5, 2026/)).toBeInTheDocument();
+
+      // Button is in the reviewed state; no "Mark as Reviewed" anymore
+      expect(
+        screen.queryByRole('button', { name: /mark as reviewed/i })
+      ).not.toBeInTheDocument();
+      const reviewedButton = screen.getByRole('button', { name: /reviewed ✓/i });
+
+      await user.click(reviewedButton);
+
+      await waitFor(() => {
+        expect(mockApiRequest).toHaveBeenCalledWith(
+          'PATCH',
+          '/api/teams/team-1/notes/session-1',
+          { reviewedAt: null }
+        );
+      });
+      await waitFor(() => {
+        expect(mockToast).toHaveBeenCalledWith(
+          expect.objectContaining({ title: 'Review mark removed' })
+        );
+      });
+    });
+  });
+
+  // F29: completion/progress semantics
+  describe('Review completion logic (F29)', () => {
+    it('counts an unlinked matched entity as remaining, not processed', () => {
+      // "Gandalf the Grey" matches the existing npc note
+      mockEntities = [
+        makeEntity({
+          id: 'entity-match',
+          text: 'Gandalf the Grey',
+          normalizedText: 'gandalf the grey',
+        }),
+      ];
+      renderPage();
+
+      expect(screen.getByText('0 / 1 processed')).toBeInTheDocument();
+      expect(screen.getByText('1 remaining')).toBeInTheDocument();
+      expect(screen.queryByText('Review Complete')).not.toBeInTheDocument();
+      // The matched entity offers a Link action
+      expect(screen.getByRole('button', { name: /link/i })).toBeInTheDocument();
+    });
+
+    it('shows Review Complete once a matched entity has been linked', () => {
+      mockEntities = [
+        makeEntity({
+          id: 'entity-match',
+          text: 'Gandalf the Grey',
+          normalizedText: 'gandalf the grey',
+        }),
+      ];
+      mockCreated = new Set(['entity-match']);
+      renderPage();
+
+      expect(screen.getByText('1 / 1 processed')).toBeInTheDocument();
+      expect(screen.getByText('0 remaining')).toBeInTheDocument();
+      expect(screen.getByText('1 linked')).toBeInTheDocument();
+      expect(screen.getByText('Review Complete')).toBeInTheDocument();
+    });
+
+    it('shows Review Complete when all new entities are dismissed (no matches)', () => {
+      mockEntities = [makeEntity({ id: 'entity-new', text: 'Captain Renn' })];
+      mockDismissed = new Set(['entity-new']);
+      renderPage();
+
+      expect(screen.getByText('1 / 1 processed')).toBeInTheDocument();
+      expect(screen.getByText('1 dismissed')).toBeInTheDocument();
+      expect(screen.getByText('Review Complete')).toBeInTheDocument();
+    });
+
+    it('mixes new and matched entities honestly in the progress math', () => {
+      mockEntities = [
+        makeEntity({ id: 'entity-new', text: 'Captain Renn' }),
+        makeEntity({
+          id: 'entity-match',
+          text: 'Gandalf the Grey',
+          normalizedText: 'gandalf the grey',
+        }),
+      ];
+      // New entity dismissed; matched entity not yet linked
+      mockDismissed = new Set(['entity-new']);
+      renderPage();
+
+      expect(screen.getByText('1 / 2 processed')).toBeInTheDocument();
+      expect(screen.getByText('1 remaining')).toBeInTheDocument();
+      expect(screen.queryByText('Review Complete')).not.toBeInTheDocument();
+    });
+  });
+
+  // F20 (PRD-003 FR-4): selection-created entities link back to the session
+  describe('Create from selection backlink (F20)', () => {
+    it('creates a backlink to the session after creating a note from a text selection', async () => {
+      const user = userEvent.setup();
+      renderPage();
+
+      // Simulate selecting "Lord Vex" in the content and choosing NPC
+      await user.click(
+        screen.getByRole('button', { name: 'simulate-selection' })
+      );
+
+      // Dialog opens pre-filled with the selection
+      const titleInput = (await screen.findByLabelText('Title')) as HTMLInputElement;
+      expect(titleInput.value).toBe('Lord Vex');
+
+      await user.click(screen.getByRole('button', { name: /create & link/i }));
+
+      // Note is created...
+      await waitFor(() => {
+        expect(mockApiRequest).toHaveBeenCalledWith(
+          'POST',
+          '/api/teams/team-1/notes',
+          expect.objectContaining({ title: 'Lord Vex', noteType: 'npc' })
+        );
+      });
+
+      // ...and backlinked to the session with the selection's snippet and
+      // offsets ("Lord Vex" starts at index 7 in the session content)
+      await waitFor(() => {
+        expect(mockApiRequest).toHaveBeenCalledWith(
+          'POST',
+          '/api/teams/team-1/notes/new-note-1/backlinks',
+          expect.objectContaining({
+            sourceNoteId: 'session-1',
+            textSnippet: 'Lord Vex',
+            evidenceType: 'Mention',
+            confidence: 0.8,
+            startOffset: 7,
+            endOffset: 15,
+          })
+        );
+      });
+    });
+
+    it('finds offsets inside content blocks when the session uses blocks', async () => {
+      const user = userEvent.setup();
+      renderPage({
+        content: null as unknown as string,
+        contentBlocks: [
+          { id: 'block-1', content: 'A quiet morning.' },
+          { id: 'block-2', content: 'Then Lord Vex appeared.' },
+        ] as unknown as null,
+      });
+
+      await user.click(
+        screen.getByRole('button', { name: 'simulate-selection' })
+      );
+      await screen.findByLabelText('Title');
+      await user.click(screen.getByRole('button', { name: /create & link/i }));
+
+      await waitFor(() => {
+        expect(mockApiRequest).toHaveBeenCalledWith(
+          'POST',
+          '/api/teams/team-1/notes/new-note-1/backlinks',
+          expect.objectContaining({
+            sourceNoteId: 'session-1',
+            textSnippet: 'Lord Vex',
+            sourceBlockId: 'block-2',
+            startOffset: 5,
+            endOffset: 13,
+          })
+        );
+      });
+    });
+  });
+});

--- a/client/src/pages/session-review.tsx
+++ b/client/src/pages/session-review.tsx
@@ -43,6 +43,8 @@ import {
 } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { useEntityDetection } from "@/hooks/use-entity-detection";
+import { useSuggestionPersistence } from "@/hooks/use-suggestion-persistence";
+import { format } from "date-fns";
 import { SelectableContent } from "@/components/selectable-content";
 import { queryClient, apiRequest } from "@/lib/queryClient";
 import type { Note, NoteType, Team } from "@shared/schema";
@@ -97,10 +99,9 @@ export default function SessionReviewPage({ team }: SessionReviewPageProps) {
     content: "",
     noteType: "npc" as NoteType,
   });
-  const [linkedEntities, setLinkedEntities] = useState<Set<string>>(new Set());
-  const [dismissedEntities, setDismissedEntities] = useState<Set<string>>(
-    new Set()
-  );
+  // Gap F18 (PRD-003): review progress must survive refresh. Persist
+  // dismissed/linked state in localStorage keyed by the session's own date,
+  // via the same hook the live editor panel uses.
   const [selectedAssociations, setSelectedAssociations] = useState<Set<string>>(
     new Set()
   );
@@ -116,6 +117,16 @@ export default function SessionReviewPage({ team }: SessionReviewPageProps) {
     queryKey: ["/api/teams", team.id, "notes"],
     enabled: !!team.id,
   });
+
+  const persistence = useSuggestionPersistence({
+    teamId: team.id,
+    sessionDate: sessionLog?.sessionDate
+      ? format(new Date(sessionLog.sessionDate), "yyyy-MM-dd")
+      : undefined,
+    enabled: !!sessionLog,
+  });
+  const linkedEntities = persistence.created;
+  const dismissedEntities = persistence.dismissed;
 
   // Create note mutation
   const createNoteMutation = useMutation({
@@ -217,7 +228,7 @@ export default function SessionReviewPage({ team }: SessionReviewPageProps) {
     },
     onSuccess: () => {
       if (selectedEntity) {
-        setLinkedEntities((prev) => new Set(prev).add(selectedEntity.id));
+        persistence.markCreated(selectedEntity.id);
       }
     },
   });
@@ -411,7 +422,7 @@ export default function SessionReviewPage({ team }: SessionReviewPageProps) {
   };
 
   const handleDismissEntity = (entityId: string) => {
-    setDismissedEntities((prev) => new Set(prev).add(entityId));
+    persistence.dismissEntity(entityId);
   };
 
   if (isLoadingSession || isLoadingNotes) {

--- a/client/src/pages/session-review.tsx
+++ b/client/src/pages/session-review.tsx
@@ -37,6 +37,7 @@ import {
   Link2,
   Plus,
   Check,
+  CheckCircle,
   X,
   Sparkles,
   Loader2,
@@ -93,6 +94,16 @@ export default function SessionReviewPage({ team }: SessionReviewPageProps) {
   const [selectedEntity, setSelectedEntity] = useState<DetectedEntity | null>(
     null
   );
+  // Gap F20 (PRD-003 FR-4): when the create dialog is opened from a text
+  // selection there is no DetectedEntity, so we capture the selection's text
+  // and (best-effort) offsets here so the created note can still be
+  // backlinked to the session instead of being silently orphaned.
+  const [pendingSelection, setPendingSelection] = useState<{
+    text: string;
+    blockId?: string;
+    startOffset?: number;
+    endOffset?: number;
+  } | null>(null);
   const [isCreateOpen, setIsCreateOpen] = useState(false);
   const [createFormData, setCreateFormData] = useState({
     title: "",
@@ -116,6 +127,38 @@ export default function SessionReviewPage({ team }: SessionReviewPageProps) {
   const { data: allNotes, isLoading: isLoadingNotes } = useQuery<Note[]>({
     queryKey: ["/api/teams", team.id, "notes"],
     enabled: !!team.id,
+  });
+
+  // Gap F19 (PRD-003 FR-5): mark/unmark the session log as reviewed via the
+  // notes PATCH endpoint's reviewedAt field.
+  const markReviewedMutation = useMutation({
+    mutationFn: async (reviewedAt: string | null) => {
+      const response = await apiRequest(
+        "PATCH",
+        `/api/teams/${team.id}/notes/${params.noteId}`,
+        { reviewedAt }
+      );
+      return response.json();
+    },
+    onSuccess: (_note, reviewedAt) => {
+      // Prefix-invalidates both the notes list and this session's detail query
+      queryClient.invalidateQueries({
+        queryKey: ["/api/teams", team.id, "notes"],
+      });
+      toast({
+        title: reviewedAt ? "Session marked as reviewed" : "Review mark removed",
+        description: reviewedAt
+          ? "This session log is now marked as reviewed."
+          : "This session log is no longer marked as reviewed.",
+      });
+    },
+    onError: (error: Error) => {
+      toast({
+        title: "Failed to update review status",
+        description: error.message,
+        variant: "destructive",
+      });
+    },
   });
 
   const persistence = useSuggestionPersistence({
@@ -183,6 +226,20 @@ export default function SessionReviewPage({ team }: SessionReviewPageProps) {
             });
           });
         }
+      } else if (sessionLog && pendingSelection) {
+        // Gap F20 (PRD-003 FR-4): selection-created entities must link back
+        // to the session too — previously this path was skipped entirely.
+        createBacklinkMutation.mutate({
+          targetNoteId: newNote.id,
+          sourceNoteId: sessionLog.id,
+          textSnippet: pendingSelection.text,
+          sourceBlockId: pendingSelection.blockId,
+          startOffset: pendingSelection.startOffset,
+          endOffset: pendingSelection.endOffset,
+          evidenceType: "Mention",
+          confidence: 0.8,
+        });
+        setPendingSelection(null);
       }
 
       toast({
@@ -304,6 +361,33 @@ export default function SessionReviewPage({ team }: SessionReviewPageProps) {
     return detectedEntities.filter((e) => entityMatches.has(e.id));
   }, [detectedEntities, entityMatches]);
 
+  // Gap F29: completion/progress semantics.
+  //
+  // Every detected entity is actionable: "new" entities offer Create/Dismiss,
+  // and matched entities offer a Link button (the one action the panel asks
+  // the user to take on them). An entity counts as processed once it has been
+  // linked (persistence.created) or dismissed; an unlinked match therefore
+  // counts toward "remaining" rather than being silently excluded — which is
+  // what previously made the numbers inconsistent and "Review Complete"
+  // unreachable whenever any match existed. Counts intersect the persisted
+  // sets with the currently-detected entity ids so stale localStorage entries
+  // from earlier content can't inflate progress.
+  const linkedCount = useMemo(
+    () => detectedEntities.filter((e) => linkedEntities.has(e.id)).length,
+    [detectedEntities, linkedEntities]
+  );
+  const dismissedCount = useMemo(
+    () =>
+      detectedEntities.filter(
+        (e) => dismissedEntities.has(e.id) && !linkedEntities.has(e.id)
+      ).length,
+    [detectedEntities, dismissedEntities, linkedEntities]
+  );
+  const totalCount = detectedEntities.length;
+  const processedCount = linkedCount + dismissedCount;
+  const remainingCount = totalCount - processedCount;
+  const isReviewComplete = totalCount > 0 && processedCount >= totalCount;
+
   // Compute proximity suggestions for all entities
   const proximitySuggestions = useMemo(() => {
     if (!sessionLog || detectedEntities.length === 0) return new Map<string, ProximitySuggestion>();
@@ -357,6 +441,7 @@ export default function SessionReviewPage({ team }: SessionReviewPageProps) {
 
   const handleCreateEntity = (entity: DetectedEntity) => {
     setSelectedEntity(entity);
+    setPendingSelection(null);
     setCreateFormData({
       title: entity.text,
       content: "",
@@ -396,7 +481,7 @@ export default function SessionReviewPage({ team }: SessionReviewPageProps) {
     setSelectedEntity(entity);
   };
 
-  // Handle creating entity from text selection
+  // Handle creating entity from text selection (gap F20, PRD-003 FR-4)
   const handleCreateFromSelection = (text: string, type: EntityType) => {
     setCreateFormData({
       title: text,
@@ -404,6 +489,35 @@ export default function SessionReviewPage({ team }: SessionReviewPageProps) {
       noteType: ENTITY_TYPE_NOTE_TYPE[type],
     });
     setSelectedEntity(null); // Not from detected entity
+    // Locate the selected text in the session content (first occurrence) so
+    // the backlink created after the note gets real offsets; if it can't be
+    // found, fall back to a snippet-only backlink.
+    let selection: {
+      text: string;
+      blockId?: string;
+      startOffset?: number;
+      endOffset?: number;
+    } = { text };
+    if (sessionLog?.contentBlocks && sessionLog.contentBlocks.length > 0) {
+      for (const block of sessionLog.contentBlocks) {
+        const idx = block.content.indexOf(text);
+        if (idx >= 0) {
+          selection = {
+            text,
+            blockId: block.id,
+            startOffset: idx,
+            endOffset: idx + text.length,
+          };
+          break;
+        }
+      }
+    } else if (sessionLog?.content) {
+      const idx = sessionLog.content.indexOf(text);
+      if (idx >= 0) {
+        selection = { text, startOffset: idx, endOffset: idx + text.length };
+      }
+    }
+    setPendingSelection(selection);
     setSelectedAssociations(new Set()); // No proximity suggestions for manual selection
     setIsCreateOpen(true);
   };
@@ -463,10 +577,39 @@ export default function SessionReviewPage({ team }: SessionReviewPageProps) {
         <Button variant="ghost" size="icon" onClick={() => navigate("/notes")}>
           <ArrowLeft className="h-5 w-5" />
         </Button>
-        <div>
+        <div className="flex-1 min-w-0">
           <h1 className="text-2xl font-medium">Review Session</h1>
-          <p className="text-muted-foreground">{sessionLog.title}</p>
+          <p className="text-muted-foreground">
+            {sessionLog.title}
+            {sessionLog.reviewedAt && (
+              <span className="ml-2 text-xs text-green-600 dark:text-green-500">
+                · Reviewed {format(new Date(sessionLog.reviewedAt), "MMM d, yyyy")}
+              </span>
+            )}
+          </p>
         </div>
+        {/* Gap F19 (PRD-003 FR-5): mark-reviewed action + visual state */}
+        {sessionLog.reviewedAt ? (
+          <Button
+            variant="outline"
+            onClick={() => markReviewedMutation.mutate(null)}
+            disabled={markReviewedMutation.isPending}
+            title="Click to un-mark as reviewed"
+          >
+            <CheckCircle className="h-4 w-4 mr-2 text-green-500" />
+            Reviewed ✓
+          </Button>
+        ) : (
+          <Button
+            onClick={() =>
+              markReviewedMutation.mutate(new Date().toISOString())
+            }
+            disabled={markReviewedMutation.isPending}
+          >
+            <CheckCircle className="h-4 w-4 mr-2" />
+            Mark as Reviewed
+          </Button>
+        )}
       </div>
 
       <ResizablePanelGroup direction="horizontal" className="min-h-[600px]">
@@ -510,9 +653,9 @@ export default function SessionReviewPage({ team }: SessionReviewPageProps) {
                   <Sparkles className="h-5 w-5" />
                   Detected Entities
                 </CardTitle>
-                {detectedEntities.length > 0 && (
+                {totalCount > 0 && (
                   <div className="text-sm text-muted-foreground">
-                    {linkedEntities.size + dismissedEntities.size} / {detectedEntities.length} processed
+                    {processedCount} / {totalCount} processed
                   </div>
                 )}
               </div>
@@ -529,7 +672,7 @@ export default function SessionReviewPage({ team }: SessionReviewPageProps) {
                 <p className="text-destructive text-sm text-center py-8">
                   Failed to detect entities: {detectionError}
                 </p>
-              ) : activeEntities.length === 0 && matchedEntities.length === 0 ? (
+              ) : detectedEntities.length === 0 ? (
                 <p className="text-muted-foreground text-sm text-center py-8">
                   No entities detected. Add content to your session log to detect
                   potential people, places, and quests.
@@ -650,9 +793,9 @@ export default function SessionReviewPage({ team }: SessionReviewPageProps) {
                     </div>
                   )}
 
-                  {/* Progress summary */}
+                  {/* Progress summary (see F29 semantics comment above) */}
                   <div className="border-t pt-4 space-y-2">
-                    {detectedEntities.length > 0 && (
+                    {totalCount > 0 && (
                       <>
                         {/* Progress bar */}
                         <div className="w-full bg-muted rounded-full h-2">
@@ -660,28 +803,27 @@ export default function SessionReviewPage({ team }: SessionReviewPageProps) {
                             className="bg-primary h-2 rounded-full transition-all"
                             style={{
                               width: `${Math.round(
-                                ((linkedEntities.size + dismissedEntities.size) /
-                                  detectedEntities.length) *
+                                (Math.min(processedCount, totalCount) /
+                                  totalCount) *
                                   100
                               )}%`,
                             }}
                           />
                         </div>
                         <div className="flex justify-between text-xs text-muted-foreground">
-                          <span>{linkedEntities.size} linked</span>
-                          <span>{dismissedEntities.size} dismissed</span>
-                          <span>{activeEntities.length} remaining</span>
+                          <span>{linkedCount} linked</span>
+                          <span>{dismissedCount} dismissed</span>
+                          <span>{remainingCount} remaining</span>
                         </div>
-                        {activeEntities.length === 0 &&
-                          matchedEntities.length === 0 && (
-                            <div className="text-center py-2">
-                              <Check className="h-8 w-8 text-green-500 mx-auto mb-2" />
-                              <p className="text-sm font-medium">Review Complete</p>
-                              <p className="text-xs text-muted-foreground">
-                                All entities have been processed
-                              </p>
-                            </div>
-                          )}
+                        {isReviewComplete && (
+                          <div className="text-center py-2">
+                            <Check className="h-8 w-8 text-green-500 mx-auto mb-2" />
+                            <p className="text-sm font-medium">Review Complete</p>
+                            <p className="text-xs text-muted-foreground">
+                              All entities have been processed
+                            </p>
+                          </div>
+                        )}
                       </>
                     )}
                   </div>
@@ -693,7 +835,13 @@ export default function SessionReviewPage({ team }: SessionReviewPageProps) {
       </ResizablePanelGroup>
 
       {/* Create Entity Dialog */}
-      <Dialog open={isCreateOpen} onOpenChange={setIsCreateOpen}>
+      <Dialog
+        open={isCreateOpen}
+        onOpenChange={(open) => {
+          setIsCreateOpen(open);
+          if (!open) setPendingSelection(null);
+        }}
+      >
         <DialogContent>
           <DialogHeader>
             <DialogTitle>Create Entity</DialogTitle>
@@ -780,7 +928,13 @@ export default function SessionReviewPage({ team }: SessionReviewPageProps) {
             )}
           </div>
           <DialogFooter>
-            <Button variant="outline" onClick={() => setIsCreateOpen(false)}>
+            <Button
+              variant="outline"
+              onClick={() => {
+                setIsCreateOpen(false);
+                setPendingSelection(null);
+              }}
+            >
               Cancel
             </Button>
             <Button

--- a/docs/NOTE_TAKING_GAP_REPORT.md
+++ b/docs/NOTE_TAKING_GAP_REPORT.md
@@ -19,6 +19,13 @@ critical/major claims were confirmed real; zero were refuted.** Minor/polish fin
 **Scoreboard**: 93 findings — 3 critical, 22 major, 53 minor, 15 polish.
 Branch: `claude/note-taking-completion-49gfvg` (PR #6, commit `de406b5`). Date: 2026-07-05.
 
+> **UPDATE (2026-07-06): all P0 and P1 items below are IMPLEMENTED** with tests on PR #6
+> (679 tests passing). That resolves all 3 criticals and the majors bundled into P0/P1:
+> F0, F2, F3, F9, F13, F17, F18, F42, F43, F47 (deep link + markdown rendering), F48,
+> F55, F56, F69, F70, F81, F85, plus bundled minors F27, F86, F87 and part of the F44/F78
+> test debt. Remaining open: the P2/P3 sections and the unbundled majors (F1, F19, F20,
+> F21, F31, F32, F33, F34, F49, F57, F58, F59) — see §3 P2 and §5 for detail.
+
 ---
 
 ## 1. Executive summary

--- a/docs/NOTE_TAKING_GAP_REPORT.md
+++ b/docs/NOTE_TAKING_GAP_REPORT.md
@@ -19,12 +19,26 @@ critical/major claims were confirmed real; zero were refuted.** Minor/polish fin
 **Scoreboard**: 93 findings — 3 critical, 22 major, 53 minor, 15 polish.
 Branch: `claude/note-taking-completion-49gfvg` (PR #6, commit `de406b5`). Date: 2026-07-05.
 
-> **UPDATE (2026-07-06): all P0 and P1 items below are IMPLEMENTED** with tests on PR #6
-> (679 tests passing). That resolves all 3 criticals and the majors bundled into P0/P1:
-> F0, F2, F3, F9, F13, F17, F18, F42, F43, F47 (deep link + markdown rendering), F48,
-> F55, F56, F69, F70, F81, F85, plus bundled minors F27, F86, F87 and part of the F44/F78
-> test debt. Remaining open: the P2/P3 sections and the unbundled majors (F1, F19, F20,
-> F21, F31, F32, F33, F34, F49, F57, F58, F59) — see §3 P2 and §5 for detail.
+> **UPDATE (2026-07-06): all P0, P1, AND P2 items below are IMPLEMENTED** with tests on
+> PR #6 (721 tests passing). P0/P1 resolved all 3 criticals plus F0, F2, F3, F9, F13,
+> F17, F18, F42, F43, F47, F48, F55, F56, F69, F70, F81, F85, F27, F86, F87.
+> The P2 pass resolved F19, F20, F21 (review-mode + session-review test files now exist),
+> F29, F32, F33, F34, F37 (client-side filter), F38, F49, F50, F51, F66, plus the
+> prod/test route unification for the notes API surface (shared handlers in
+> server/notes-handlers.ts).
+>
+> **P2-2 decision (block substrate)**: resolved as the OFFSET-BASED model — backlink
+> clicks scroll to and select the exact mention via stored offsets, backlinks re-index
+> or are removed on content edits (server/backlink-reindex.ts), and PRD-001/004/005
+> carry amendments documenting the decision. The block-based editor was NOT built (F1
+> formally superseded, F11 moot).
+> **P2-1 decision (quest transitions)**: status badges/filter/hover shipped; the strict
+> FR-2 transition state machine was deliberately NOT enforced (fights capture-first) —
+> F31 closed as won't-fix per the PRD-004 amendment.
+>
+> Still open by choice: P3 hygiene items, the design-review recommendations (§6),
+> and unbundled majors F57 (diff-preview filters), F58 (enrichment undo UI +
+> noteType revert), F59 (Item/Faction types — recommend descoping in PRD-030).
 
 ---
 

--- a/docs/NOTE_TAKING_GAP_REPORT.md
+++ b/docs/NOTE_TAKING_GAP_REPORT.md
@@ -1,0 +1,321 @@
+# Note-Taking Done-ness Report
+
+**Purpose**: the complete, verified gap list between the note-taking PRDs' intent
+(per `NOTE_TAKING_ROADMAP.md`) and what the codebase actually does — so the owner can pick
+what gets built to call note-taking *done*. No gap-fixing code has been written for anything
+in this report (per instruction: audit + report first). The two pre-approved quick items —
+issue #5 branding and the PRD-023 DB constraint — are already handled (branding fixed on PR #6;
+the DB constraint turned out to already exist at `shared/schema.ts:227-232`).
+
+**Method**: 36 agents (~1.9M tokens of investigation). Ten auditors, one per PRD cluster,
+each requiring file:line evidence and treating "component exists but is never rendered" as a
+gap. A senior product agent walked the end-to-end DM journey in code against the roadmap's
+intent. A senior design agent vetted every note-taking component against `design_guidelines.md`.
+Then every critical/major claim was adversarially verified — 15 by dedicated skeptic agents,
+10 by direct main-session spot-checks after the skeptics hit a rate limit. **All 25
+critical/major claims were confirmed real; zero were refuted.** Minor/polish findings
+(68) were not individually re-verified but carry the same evidence standard.
+
+**Scoreboard**: 93 findings — 3 critical, 22 major, 53 minor, 15 polish.
+Branch: `claude/note-taking-completion-49gfvg` (PR #6, commit `de406b5`). Date: 2026-07-05.
+
+---
+
+## 1. Executive summary
+
+The core capture experience genuinely delivers the roadmap thesis: open Notes, type into the
+always-ready Today editor, autosave with visible status, no blank sessions, no structural
+decisions demanded at capture time. Entity pages, backlinks, quest promotion, and the Nuclino
+import machinery are real, reachable products — not just passing tests (626/626 green).
+
+But walking the actual DM journey exposes **four clusters that block calling it done**, none
+of which require architectural change:
+
+1. **Privacy is client-side theater.** The production notes-list API ships every private note
+   to every team member; only the browser hides them. The test suite passes because the test
+   harness route filters correctly while the production route doesn't — the exact prod/test
+   divergence failure mode PRD-021 documented.
+2. **The structure-later loop's contract is broken at runtime.** Suggestion dismiss/reclassify
+   state is keyed to entity IDs that are regenerated on every keystroke's detection re-run, so
+   dismissed suggestions resurrect ~750ms later while the DM is typing. The persistence layer
+   passes its unit tests (hand-fixed IDs) but is functionally inert in real use.
+3. **Quest capture from natural prose is dead end-to-end.** Both the live detection patterns
+   and the cleanup quest patterns are capitalized-only, so PRD-002's own acceptance examples
+   ("asked us to find the artifact", "We need to defeat the dragon") produce nothing — and the
+   Haiku path that could catch them is unreachable for saved sessions.
+4. **AI trust violations.** The relationship cache silently persists *direction-inverted*
+   graph edges for any note over ~100 chars; the post-import AI review dialog is fully built
+   but mounted nowhere (the import dialog literally tells users to go review suggestions on a
+   page that has no review UI); pending unreviewed AI edges render on entity pages
+   indistinguishable from confirmed facts; and the "AI Cleanup" button never calls AI in the
+   normal saved-session case yet toasts "AI Cleanup Complete."
+
+Fix the five P0s and six P1s below (§3) and this is an honest, owner-reviewable "done."
+
+## 2. Done-ness verdict by pillar (senior product review)
+
+| Pillar | Verdict | One-line reason |
+|---|---|---|
+| Live capture (session-first, zero-friction) | **DONE with caveats** | Core promise holds; but sessions can't be back-dated or re-titled, delete-to-empty leaves a ghost session, and switching notes mid-debounce drops typed text |
+| Structure-later review loop | **NOT DONE** | Detection engine excellent (real web worker, 47 tests), but dismissals resurrect on every keystroke and natural-prose quests are never detected |
+| Knowledge graph: entity pages, backlinks, quests | **DONE with caveats** | Strongest pillar; but accepted relationships don't appear on already-open entity pages (stale cache), backlink clicks don't scroll/highlight the mention, and quest status is invisible outside the editor |
+| Nuclino import | **DONE with caveats** | Best-engineered subsystem; but imported wikis display raw `.md?n` link syntax (resolved links computed, never rendered) and "Private" visibility is client-side only |
+| AI assist quality & trust | **NOT DONE** | Cache direction-inversion corrupts the graph; enrichment review UI unreachable; "AI Cleanup" mislabeled; paywall CTA lands on a 404 |
+| Privacy & data-integrity guarantees | **NOT DONE** | Private notes readable by all members via API; needs-review exposes and allows mutation of other users' private notes |
+
+## 3. The pick-list (prioritized recommendations)
+
+Choose what to build. P0 = blocks "done." P1 = expected from PRD intent; you'd hit these in
+your first minutes of dogfooding. Effort: S < half day, M = 1–2 days, L = multi-day.
+
+### P0 — blocks calling note-taking done
+
+| # | Recommendation | Effort | Fixes findings |
+|---|---|---|---|
+| P0-1 | **Apply the privacy filter to production `GET /notes` and needs-review.** Reuse the existing `canViewNote` (already applied at `routes.ts:788`) on the list route and the needs-review endpoint. Also stops members from approving/rejecting classifications on other users' private notes. | S | F0, F48, F81, F9 |
+| P0-2 | **Key suggestion persistence by stable identity (type + normalizedText), not regenerated entity IDs.** One function change in `entity-detection.ts:101-103` (the PRD-049 cleanup suggestions already do deterministic IDs correctly) + re-point the persistence hook. Unblocks Session Review persistence too. | S | F17, F18, F27 |
+| P0-3 | **Fix the AI cache relationship direction inversion.** `setRelationship` stores a 100-char truncation, `getRelationship` hashes full content — hashes can never match, so cached directional edges (QuestHasNPC etc.) persist reversed. Store matching truncations or an explicit direction flag; add the end-to-end cache test that would have caught it. | S | F69, F74 |
+| P0-4 | **Close the AI enrichment review dead end.** Mount the fully-built `EnrichmentReviewDialog` in Import Management (endpoints exist), and badge or filter pending/rejected AI edges on entity pages so they're not indistinguishable from confirmed facts. | M | F55, F64, F89, F58 |
+| P0-5 | **Make quest detection catch natural prose.** Add the case-insensitive action-verb patterns from PRD-002's own FR-2 table ("need to", "asked us to", "must defeat") to both `QUEST_PATTERNS` and the PRD-049 `QUEST_ACTION_PATTERNS`, with tests from the PRD's table. | S | F13 (compounded by F70) |
+
+### P1 — should land before your review pass
+
+| # | Recommendation | Effort | Fixes findings |
+|---|---|---|---|
+| P1-1 | **Editable session date + editable session title.** Both server paths already work; the UI just never renders a date field and hides the title input for session logs. Back-dating yesterday's game is THE canonical DM workflow. | S | F2, F3 |
+| P1-2 | **Invalidate note-detail queries after relationship accept / link / undo.** With `staleTime: Infinity`, an already-viewed entity page never shows the relationship you just accepted — the Accept button looks broken. | S | F85, F87 |
+| P1-3 | **Truth-in-labeling for AI Cleanup.** Saved sessions post to the deterministic-heuristics endpoint but the button says "AI Cleanup" and toasts "AI Cleanup Complete." Either wire `extract-entities` (Haiku) into the saved-session path and merge, or split into "Suggestions" (always available — they're deterministic and shouldn't be behind the AI gate at all, per roadmap principle 9) and a real gated "AI Cleanup." | M | F70, F86, F75 |
+| P1-4 | **Fix the paywall CTA 404 and the `/notes/:id` deep-link no-op.** Paywall navigates to `/teams/:id/settings` (no such route → 404); `/notes/:id` renders NotesPage but the param is never read, so deep links silently show the default view. | S | F56, part of F47 |
+| P1-5 | **Render resolved markdown links for imported notes.** `contentMarkdownResolved` is computed and stored but never displayed — imported pages show raw `[text](page.md?n)` syntax in a plain textarea. Minimum viable: read-mode markdown renderer for imported notes with links routed through the fixed `/notes/:id`. The single largest gap between "import works" and "import is a product." | L | F47 |
+| P1-6 | **Capture-integrity pair: flush the pending draft when switching notes, and remove/hide a session deleted to empty.** Losing even one sentence of live session notes is the worst failure this product can have. | S | F43, F42, F44 |
+
+### P2 — valuable, not blocking
+
+| # | Recommendation | Effort |
+|---|---|---|
+| P2-1 | Quest status in lists: badge on quest rows (the `QUEST_STATUS_COLORS` map is currently dead code), status filter, lead-vs-active distinction. Transition-graph enforcement (F31) deliberately *not* bundled — a strict state machine arguably fights capture-first and deserves your explicit call. | M |
+| P2-2 | **Decide the block-substrate question** (the "big architectural gap" flagged when you chose audit-first): production notes never have `contentBlocks`, so per-block backlink deep-linking and snippet re-indexing are unbuildable as specced. Either invest in a block-based editor (L) or formally amend PRD-001/005 to the offset-based model the PRD-047 data already supports and implement scroll-to-offset highlighting (M). | L or M |
+| P2-3 | Unify prod and test route implementations (shared handlers). The privacy leak is the *third* documented instance of the prod/test divergence family (PRD-021, PRD-023, now this). Makes the bug class structurally impossible. | M |
+| P2-4 | Import-run truthfulness: set `failed` status on error (today a mid-run crash shows as a phantom success), fix empty-page stats under partial selection, add the missing "View details" action (endpoint exists, UI never calls it). | M |
+| P2-5 | Session Review page polish: reviewed-flag + visual distinction (PRD-003 FR-5), fix the "Review Complete" state that can never display when matches exist, create backlinks for selection-created entities (currently silently orphaned), add the PRD-mandated test files. | M |
+
+### P3 — hygiene
+
+Accessibility + doc sweep: aria-labels on icon-only buttons, aria-live for suggestion arrival,
+delete dead `mentioned-in-section.tsx` (after porting its blockId-aware navigation signature),
+extract the thrice-duplicated type-color maps, update stale PRD statuses (PRD-018/019 still say
+"Proposed" despite shipped code), drop dead `teams.aiEnabled` columns, amend PRD-001 to document
+the deliberate drift to shared team sessions. (S overall)
+
+## 4. Confirmed critical findings (3)
+
+**F0 · PRD-001 · Privacy: production `GET /notes` returns other users' private notes.**
+`server/routes.ts:716-727` sends `storage.getNotes(teamId)` verbatim; `storage.getNotes`
+(`server/storage.ts:325-331`) has no privacy predicate; hiding happens only in the browser
+(`client/src/pages/notes.tsx:94-99`). The test harness route filters correctly
+(`test-routes.ts:289-291`), so the privacy acceptance test passes against code that doesn't
+run in production. Fix should use `canViewNote` (routes.ts:163) so DM visibility semantics stay
+consistent. *(Effort S)*
+
+**F17 · PRD-022 · Suggestion persistence is keyed to IDs regenerated every detection run.**
+`generateEntityId` uses `Date.now()+Math.random()` (`shared/entity-detection.ts:101-103`);
+the localStorage hook stores those raw IDs; detection re-runs 750ms after every keystroke.
+Dismissed suggestions reappear mid-game; reclassifications reset; accepted entities resurface.
+Unit tests pass only because they use hand-fixed IDs. *(Effort M — includes migrating stored state)*
+
+**F55 · PRD-016 · The post-import AI review UI exists but is mounted nowhere.**
+`EnrichmentReviewDialog` (`client/src/components/enrichment-review-dialog.tsx`) is imported by
+zero files; all backend endpoints exist (`routes.ts:2472, 2527, 2611, 2710`). The import dialog
+tells users to "Check the Import Management page to review AI suggestions" — a page with only a
+delete button. Pending relationships/classifications are stuck forever while rendering on
+entity pages as if confirmed. *(Effort S to mount; M with the pending-edge badging from P0-4)*
+
+## 5. Confirmed major findings (22)
+
+Grouped; every one verified. Finding numbers match the pick-list references above.
+
+### Capture & sessions
+- **F1 (PRD-001, L)** — `contentBlocks` is schema/API-only; the editor sends plain text, so every
+  real session has `contentBlocks: null` and per-block traceability is vacuous in production.
+  A captured production log confirms it empirically. → P2-2 decision.
+- **F2 (PRD-008, M)** — No UI anywhere to view or edit `sessionDate`; back-dating impossible.
+  Server PATCH already supports it. → P1-1.
+- **F3 (PRD-008, S)** — Title input is hidden for `session_log` notes
+  (`notes-editor-panel.tsx:320`); autosave already sends title, only the input is missing. → P1-1.
+
+### Detection & review loop
+- **F13 (PRD-002, S)** — `QUEST_PATTERNS` are case-sensitive capitalized-only; PRD-002's own
+  acceptance-table inputs produce no quest suggestions. → P0-5.
+- **F18 (PRD-003, S)** — Session Review page keeps dismissed/linked state in plain `useState`;
+  refresh resets all progress. The purpose-built persistence hook exists and is unused there. → P0-2.
+- **F19 (PRD-003, M)** — No "mark session reviewed" flag, action, or visual distinction anywhere;
+  only a transient in-page message. → P2-5.
+- **F20 (PRD-003, S)** — Create-from-text-selection deliberately nulls `selectedEntity`
+  (`session-review.tsx:395`), so the backlink step is skipped — selection-created entities are
+  silently orphaned from their session. → P2-5.
+- **F21 (PRD-003, M)** — None of the PRD-mandated review-mode test files exist despite Done status. → P2-5.
+
+### Knowledge graph
+- **F31 (PRD-004, M)** — Quest status transition graph enforced nowhere; a lead can jump straight
+  to done (client dropdown unrestricted, PATCH persists anything). Deliberately left for your
+  call — strict enforcement may fight capture-first. → P2-1 note.
+- **F32 (PRD-004, M)** — No status badge/filter on quest lists; `QUEST_STATUS_COLORS` is dead code;
+  status visible only inside the editor detail view. → P2-1.
+- **F33 (PRD-005, M)** — Backlink click opens the note but ignores `sourceBlockId`: no scroll, no
+  highlight (`note-detail-sections.tsx:166`). On long sessions the user hunts manually. → P2-2.
+- **F34 (PRD-005, M)** — Backlinks are not re-indexed on content edit and not removed on block
+  deletion; snippets go stale, violating "backlinks always reflect current state." → P2-2.
+
+### Import
+- **F47 (PRD-015, M)** — Resolved links (`contentMarkdownResolved`) never rendered; imported pages
+  show raw Nuclino syntax in a textarea; `/notes/:id` route param never read. → P1-4/P1-5.
+- **F48 (PRD-015A, S)** — Private *imports* readable by all members via the same list-API hole as F0. → P0-1.
+- **F49 (PRD-015A, S)** — Import Management has no "View details"; the details endpoint
+  (`routes.ts:2316-2348`) has zero UI callers. → P2-4.
+
+### AI import & preview
+- **F56 (PRD-031, S)** — Paywall CTA navigates to `/teams/:id/settings`; router only has `/settings`;
+  lands on NotFound. The paywall's entire conversion path is broken. → P1-4.
+- **F57 (PRD-030, S)** — The diff-preview "Changes" filters (All/Changed/Low-confidence/AI-discovered)
+  don't exist — no filter state or buttons in the 427-line component, though the PRD's own footer
+  claims they shipped. → pick if desired (not in P0/P1; fold into P2-4 or skip).
+- **F58 (PRD-016, M)** — Enrichment-batch undo is API-only, unreachable from UI, and doesn't revert
+  noteType changes applied at approval (no snapshot). → P0-4 follow-up.
+- **F59 (PRD-030, L)** — Item/Faction entity types promised by the diff-preview PRD don't exist
+  anywhere in the system (types, provider, UI). Recommend explicitly descoping in the PRD rather
+  than building. → your call; suggest documenting as descoped.
+
+### AI infrastructure
+- **F69 (PRD-043, S)** — Cache relationship direction inversion (detail in §1 item 4; verified in
+  `ai-cache.ts:292-332` vs `:46-56`). Silent graph corruption on every cache hit for real notes. → P0-3.
+- **F70 (PRD-026, M)** — "AI Cleanup" on any saved session posts to the deterministic
+  cleanup-suggestions endpoint (`entity-suggestions-panel.tsx:142-156` branches on
+  `sessionNoteId`); Haiku is reachable only in unsaved today-mode. Mislabeled AI. → P1-3.
+
+### Finish-line re-vet (PR #6 work)
+- **F85 (PRD-049, S)** — Backlink/relationship mutations never invalidate note-detail queries;
+  with `staleTime: Infinity` an already-open entity page never shows newly accepted
+  relationships. (My own gap from the PR #6 implementation — confirmed.) → P1-2.
+
+## 6. Design review (senior designer)
+
+**Verdict**: foundations are good — coherent badge/icon language on core surfaces, informative
+empty states everywhere, a well-executed autosave indicator, and detection genuinely respects
+zero-typing-latency. Three systemic problems undermine it:
+
+1. **Surface drift.** Color maps, type defaults, action verbs, and confidence displays are
+   copy-pasted per file and have diverged:
+   - NPC suggestion cards are **green** while NPC means **orange** everywhere else (and green
+     also means Character *and* high-confidence — three meanings for one hue).
+   - The same detected "place" becomes an **Area** if accepted from the editor panel but a
+     **POI** if accepted from the Review All page.
+   - Three surfaces use three verb pairs (Accept/Dismiss · Create/Dismiss · Approve/Reject) and
+     four different confidence encodings, one of which (Needs Review's 0.5-threshold dot)
+     contradicts the canonical 0.80/0.65 buckets.
+   - *Highest-leverage single fix*: one shared type-color/label/confidence-badge module consumed
+     by all three surfaces.
+2. **The suggestions panel outgrew its design.** Four sections (entities, existing, relationships,
+   quests) with identical flat headers stack unbounded below the textarea — after AI Cleanup this
+   can add 1500+px, with relationship/quest sections invisible below the fold and the header count
+   excluding half the content. Recommend: per-section collapse + counts, max-height with internal
+   scroll, header renamed "Suggestions" with a true total.
+3. **No responsive or dark-mode discipline.** The split view has no mobile fallback
+   (min-w-250px left panel makes phones unusable; hover-only previews unreachable on touch;
+   the `use-mobile` hook exists and is unused); suggestion grids use viewport breakpoints inside
+   a width-variable panel; `text-green-600`/`text-amber-600` badges have zero `dark:` variants
+   against the guidelines' dark palette.
+
+Accessibility: icon-only dismiss/delete/back buttons lack aria-labels (the team clearly knows
+the pattern — `note-detail-sections.tsx` does it right); confidence dots are color-only and
+keyboard-invisible; the suggestion card is a clickable div containing buttons (nested-interactive);
+no aria-live announces suggestion arrival.
+
+Full design findings (4 major, 8 minor, 6 polish) with per-component recommendations are in the
+audit data; the major four are: mobile fallback for the split view (M), suggestions-panel
+hierarchy (M), place→POI vs place→Area divergence (S), and the NPC color flip (S).
+
+## 7. Minor findings (53) — one-liners
+
+Worth batching opportunistically; none blocks done-ness. Grouped by theme:
+
+**Spec deviations with workarounds**: F4 no dedicated sessions endpoint · F5 session rows lack
+visibility indicator · F8 session logs created team-visible not private (deliberate drift —
+amend PRD) · F10 Sessions/Notes still distinct types vs unified model · F12 autosave timings
+750ms/10s vs spec 2s/15s · F16 single-mention proper-noun confidence deviates · F25 suggestions
+grouped New/Existing not by entity type · F39 proximity tiers use character thresholds not
+sentence/paragraph · F52 unresolved links rewritten to `#unresolved` instead of left intact ·
+F54 collections not imported as distinct type · F63 AI-detected quests don't default to Open ·
+F76 uses claude-3-haiku-20240307 not the spec'd 3.5-haiku.
+
+**Correctness edges**: F6 unique index can't deploy until prod duplicate cleanup runs (no script
+checked in) · F7 idempotency non-atomic — true race returns 500 · F9 idempotent POST can return
+another author's private session · F22 bulk accept doesn't link bulk-created entities to each
+other · F27 persistence key uses today's date even when editing older sessions · F35 rejected
+proximity associations not remembered · F36 review-flow links one-directional · F38
+default-to-lead only enforced in MemoryStorage, not production storage · F50 partial empty-page
+selection records wrong stats · F51 import runs never marked failed · F53 upsert has no DB
+unique constraint · F61 "enriching" state still shows an indeterminate bar · F62 three-state
+entitlement gating not implemented · F65 aiEnhanced/aiModel not persisted on import_runs ·
+F66 AI preview cache expiry mid-review has no recovery · F72 enrichment worker never gets PC
+names (splits the cache from the preview path) · F73 cache stats omit hit rate · F75 AI
+item/faction coerced to NPC with fabricated offsets · F82 needs-review right-panel sync fails
+silently for notes not in the visible list · F88 accepted/dismissed relationship-suggestion
+statuses are in-memory only · F90 Undo + inline snippet lost after reload · F91 Review All
+page's Link doesn't follow PRD-047 semantics (no evidence window, no Undo).
+
+**Missing UI affordances**: F23 no Review icon on session rows · F26 review page lacks grouping
++ source-text highlight on focus · F37 no server-side status filter · F40 entity search ignores
+backlink content · F42 delete-to-empty leaves ghost session (also P1-6) · F43 draft dropped on
+switch (also P1-6) · F60 relationship diff omits evidence-type badges/counts · F86 deterministic
+suggestions gated behind AI toggle (also P1-3).
+
+**Test debt**: F11, F14, F15, F21, F44, F71, F74, F78, F79, F80 — endpoints and flows the PRDs
+claim are covered but have zero tests (classifications PATCH, POI reclassify, aiEnabled 403
+gating, extractEntities, cache end-to-end, hover preview, block utilities, EntityDetector
+interface). Largely a consequence of the prod/test route split (P2-3).
+
+**Privacy adjacents**: F81 needs-review exposes private-note titles + AI explanations to all
+members and lets them mutate those classifications (bundled into P0-1).
+
+## 8. Polish findings (15)
+
+F24 Review All lacks count badge · F28 stale-key cleanup semantics · F29 Review Complete
+unreachable with matches · F30 no SR announcement for new suggestions · F41 dead
+mentioned-in-section.tsx · F45 residual "Location" strings · F46/F68 PRD statuses never updated ·
+F67 diff summary omits some category cards · F77 no cache prune cron · F83 badge map duplicated
+3× · F84 dead teams.aiEnabled columns · F92 icon-only X buttons unnamed · plus the two design
+polish items (amber triple-duty, duplicate "Notes" headings).
+
+## 9. What's verified working (so the review can start from trust)
+
+- **Capture**: today-mode with lazy creation, four-state autosave, newest-first sessions,
+  duplicate-race closed (idempotency in both routes + DB partial unique index), no blank sessions.
+- **Detection**: real Web Worker off the main thread; all 7 PRD-024 + 3 PRD-025 quality fixes
+  in code with 47 passing tests; genre-tuned vocab.
+- **Review surfaces**: session-review page routed and functional (split view, pre-filled create,
+  selection popover, proximity pre-checks); editor suggestions panel wired with fuzzy
+  link-to-existing, bulk accept + confirm, reclassify incl. POI.
+- **Knowledge graph**: entity pages never blank (content seed, references with privacy
+  redaction, grouped relationships with buckets and role-gated delete); PRD-047 link/undo flow;
+  PRD-049 relationship + quest promotion with full provenance; PRD-050 link evidence at 0.90
+  with canonical direction and line snippets.
+- **Import**: validation, classification priority order, attribution, private-by-default
+  choice, rollback with snapshots + suggestion-orphan cleanup, granular empty-page selection,
+  real progress feedback, genuine dry-run AI diff with entitlement enforcement, paywall stub
+  with the real Hobgoblin example.
+- **AI infra**: JSON repair across all three parsers (48 tests), prompt/validator vocab aligned,
+  caching wired into both worker and preview paths incl. negative caching, CLI admin tool,
+  per-member gating end-to-end, needs-review panel fully actionable.
+
+## 10. Corrections to NOTE_TAKING_ROADMAP.md
+
+- §9 said PRD-023's Phase-2 DB constraint may not have landed — **it did**
+  (`shared/schema.ts:227-232`). But note new F6: it can't be applied to a prod DB that still
+  contains duplicates, and no cleanup script is checked in.
+- §5 asserted PRD-047–050 shipped clean; the re-vet found real caveats (F85 stale-cache,
+  F86 AI-gating of deterministic suggestions, F88/F90 reload-state loss, F91 Review-All parity).
+
+---
+
+*Next step: pick from §3 (e.g. "do P0 + P1", or list items). Anything selected gets implemented
+with tests on PR #6.*

--- a/docs/NOTE_TAKING_ROADMAP.md
+++ b/docs/NOTE_TAKING_ROADMAP.md
@@ -232,10 +232,11 @@ recur across 3+ independent PRDs — treat deviations from them as a deliberate,
 
 ## 9. Open threads / things to verify if picking this back up
 
-- **PRD-023's optional phases**: a DB-level partial unique index on
-  `(team_id, DATE(session_date))` for session logs, and a one-time production duplicate-row
-  cleanup query, were marked optional/Phase 2-3 — confirm whether these ever landed, since
-  they're the "defense in depth" half of the fix (server-side idempotency, Phase 1, is done).
+- **See `NOTE_TAKING_GAP_REPORT.md`** (2026-07-05) for the full verified gap audit of every
+  claim in this file — including corrections to this section.
+- **PRD-023's optional phases**: the Phase-2 DB partial unique index DID land
+  (`shared/schema.ts:227-232`), but it cannot be applied to a production DB that still
+  contains duplicate rows, and the Phase-3 cleanup script was never checked in.
 - **GitHub issue #5** (Quest Keeper branding) is still open and unrelated to note-taking —
   quick two-file fix if picked up next.
 - **PR #6** (closes issues #1–#4 / PRD-047–050) is open as a draft; being watched via an

--- a/docs/NOTE_TAKING_ROADMAP.md
+++ b/docs/NOTE_TAKING_ROADMAP.md
@@ -1,0 +1,245 @@
+# Helm Note-Taking Roadmap & Intent Summary
+
+**Purpose of this file**: a single reference synthesizing every story (GitHub issue + PRD doc)
+that shapes Helm's note-taking system — what was asked for, what shipped, and the design
+philosophy that recurs across all of it. Not itself a PRD; a map of the PRDs. Regenerate/update
+this by re-reading `docs/prd/*.md` and the GitHub issue tracker if it drifts out of date.
+
+Generated: 2026-07-05. Source: 55 PRD docs in `docs/prd/`, 5 GitHub issues (theronnieguidry/helm).
+
+---
+
+## 1. The core thesis (read this first)
+
+Every note-taking PRD in this repo, from the very first (PRD-001) to the most recent
+(PRD-047–050), restates some version of one idea:
+
+> **Capture must never require structure. Structure is a cleanup task done later, assisted
+> by suggestions the user can accept, dismiss, or ignore — never one the system imposes
+> automatically.**
+
+This shows up as:
+- "Session-first, structure-later" (PRD-001's own words)
+- "Proto-quest support: allow incomplete discovery" (PRD-004)
+- "Detection identifies candidates only — no automatic entity creation" (PRD-002, PRD-006, PRD-022 — nearly verbatim in three places)
+- The editor as a "live notebook... always ready to write," never a modal flow (PRD-019)
+- AI as an augmentation layer that must never override deterministic/structural signals
+  (Nuclino import PRDs) and must never block core functionality (PRD-027/028/030/031)
+
+If a future feature request seems to conflict with this thesis (e.g., "auto-create an entity
+when confidence is high enough"), that's a signal to pause and confirm intent — every PRD to
+date has explicitly avoided that pattern.
+
+---
+
+## 2. The note-taking pipeline, as it evolved
+
+```
+PRD-001 Session Logs (capture)
+   -> PRD-002 Entity Detection (candidates, client-side, zero-latency)
+   -> PRD-003 Post-Session Review (bulk structure pass, split panel)
+   -> PRD-006 Proximity Suggestions (auto-suggest relationships by text distance)
+   -> PRD-005 Backlinks (entity <-> source-block traceability, bidirectional)
+   -> PRD-004 Quest Status Progression (lead -> todo -> active -> done/abandoned)
+   -> PRD-022 Real-Time Suggestions (collapse review into the live editor itself)
+   -> PRD-026 Haiku AI Extraction (hybrid pattern+AI entity/relationship extraction)
+   -> PRD-047/048/049 (2026-07: link evidence, entity pages, relationship suggestions,
+      quest promotion — the "finish line" work, see §5)
+```
+
+In parallel, a **second pipeline** grew around **importing existing external notes (Nuclino)**
+into this same system — see §4.
+
+And a **third, supporting pipeline** grew around **AI classification quality/trust/cost** that
+both the live editor and the importer depend on — see §6.
+
+---
+
+## 3. Core capture & entity pipeline (PRD-001 to PRD-026, PRD-008, PRD-019, PRD-021, PRD-023)
+
+All of these are **Done** except where noted.
+
+| PRD | What it did | Why it matters going forward |
+|---|---|---|
+| [001](prd/PRD-001-session-logs.md) | New `session_log` note type, block-based content (`ContentBlock[]` with stable IDs), autosave (2s debounce/15s cap), private-by-default, chronological "Sessions" list | Block IDs are the substrate everything else (backlinks, entity refs) depends on. Don't break stable IDs across edits. |
+| [002](prd/PRD-002-entity-detection.md) | Client-side/web-worker pattern detection (Person/Place/Quest), session-scoped ephemeral suggestions, designed behind a replaceable `EntityDetector` interface | The interface abstraction was deliberate — anticipates AI upgrade (delivered PRD-026). Zero typing-latency is a hard constraint. |
+| [003](prd/PRD-003-post-session-review.md) | Split-panel review screen, bulk accept/dismiss/create-from-selection, "reviewed" progress tracking | The template for later Cleanup UIs — "cleanup, not creative work" in <5 clicks. |
+| [004](prd/PRD-004-quest-status-progression.md) | 5-state quest lifecycle (lead/todo/active/done/abandoned), strict transition graph, escalating required fields | "lead" = title-only capture; don't force full quest details at discovery time. |
+| [005](prd/PRD-005-backlinks.md) | `backlinks` table, bidirectional Mentioned-In section, click-to-navigate-and-highlight, auto-updates on edit/delete | "Backlinks always reflect current state — no stale references." Trust/auditability mechanism reused everywhere later (imports, AI cleanup). |
+| [006](prd/PRD-006-proximity-suggestions.md) | Distance-based relationship suggestions (±200 chars/paragraph), confidence tiers, `AssociationSuggester` interface | "Suggest, don't assume." Same interface-abstraction pattern as PRD-002; delivered on by PRD-049's relationship suggestions. |
+| [008](prd/PRD-008-session-log-date-default-and-remove-notes-vs-session-logs-tabs.md) | Unified all notes under one "Sessions" model, removed Notes-vs-Session-Logs tab split, `sessionDate` as distinct editable field | Explicit non-goals: no entity-model changes, no real-time collab. Scope discipline worth imitating. |
+| [019](prd/PRD-019-notes-screen-layout-updates-and-left-panel-features.md) | Left filter panel + always-ready "Today" editor (no "New Session" click needed), hover preview, inline reclassification, Location→Area rename | "No blank session note" rule — a session record only exists once ≥1 char is typed. This exact rule caused the PRD-023 race condition. |
+| [021](prd/PRD-021-session-note-save-failure.md) | Bugfix: prod route wasn't converting `sessionDate` string→`Date` before Drizzle insert (test route had the fix, prod didn't) | Recurring lesson: keep `server/routes.ts` and `server/test/test-routes.ts` logic in sync — test-route correctness ≠ prod-route correctness. |
+| [022](prd/PRD-022-realtime-entity-suggestions-in-editor.md) | Moved suggestions into the live editor itself (collapsible panel below), localStorage session-scoped persistence, "Accept All High-Confidence" | Insight: note-takers have natural lulls (dice rolls, rules lookups) — that downtime is a review opportunity, not a distraction to protect against. |
+| [023](prd/PRD-023-duplicate-session-entries-race-condition.md) | Fixed race condition creating duplicate session rows on rapid typing (client ref reset before React state re-render) | Phase 1 (server-side idempotency) done; DB unique index + prod cleanup query were optional phases — check if those ever landed if duplicates resurface. |
+| [024](prd/PRD-024-entity-detection-quality-improvements.md) | 7 pattern-matching bugs fixed against real fantasy-TTRPG text (compound-name merging across sentences, vocab expansion, dedup, comma-lists, spurious fragments) | Detection is explicitly tuned for **fantasy TTRPG genre**, not general NER — if supporting other genres/systems, vocab lists need review. |
+| [025](prd/PRD-025-entity-detection-followup-bugs.md) | Second round: sentence-start blindness, prefix-match dedup, article+title back-references ("the Duke") | Detection hardening was iterative (002→024→025), not one-shot — expect more edge cases if genre/content variety grows. |
+| [026](prd/PRD-026-haiku-entity-extraction.md) | Prototyped Claude Haiku entity/relationship extraction; explicit recommendation for **hybrid** (pattern + AI merge), not AI replacing patterns | "AI augments, doesn't replace, deterministic logic." Patterns caught entities Haiku missed (e.g. "Samwell") — don't drop the pattern engine. |
+
+---
+
+## 4. Nuclino import pipeline (PRD-015, 015A, 016, 017, 018, 030, 031, 034, 035, 036, 042, 044, 050)
+
+Arc: **mechanical MVP → safe/reversible → AI-enhanced/reviewable → hardened via real usage.**
+All Done except where noted.
+
+| PRD | What it did | Why it matters going forward |
+|---|---|---|
+| [015](prd/PRD-015-nuclino-zip-import.md) | Baseline ZIP importer: parse .md → notes, resolve internal links, collection-based classification (Person/Place/Quest/Note), idempotent upsert by `(teamId, sourceSystem, sourcePageId)` | Explicit non-goals: no AI/semantic enrichment, no cross-source dedup — deliberately deferred, not forgotten. Designed provider-agnostic for future connectors (OneNote, Evernote). |
+| [015A](prd/PRD-015A-nuclino-import-attribution-visibility-and-rollback-imports.md) | Attribution (`createdByUserId`/`importRunId`), Private/Team visibility choice (default Private), `import_runs` table, Settings→Imports view/delete (rollback), `note_import_snapshots` | Rollback is called a "panic button" — imports must always be reversible. Any new import-adjacent feature (e.g. suggestion-created entities, PRD-034) must respect this cascade-delete contract. |
+| [016](prd/PRD-016-nuclino-import-enhancement-AI-enrichment-and-relationship-mapping.md) | Optional AI classification + relationship extraction on import, review/approve UI, "internal links = ground truth, mentions = suggestions" | Quest Done→Open lock can't be overridden by AI without explicit approval. Kept as a separate pipeline step so baseline import stays fast/reliable regardless of AI. |
+| [017](prd/PRD-017-nuclino-import-bugfixes.md) | 4 fixes found via real 105-file dataset testing (title cleaning, session-log detection, whitespace trim, AI rate-limit delay) + 4 documented accepted limitations | Classification priority order: Collection > Person > Place > Quest-Done > Quest-Todo > session-log-title > Note. Structural signals always outrank AI. |
+| [018](prd/PRD-018-import-preview-dialog-layout-bugs.md) | Fixed dialog overflow (4-col summary grid, metadata line, visibility dropdown) via Playwright screenshot evidence | Root cause: `sm:max-w-md` too narrow once visibility selector + AI toggle were added. Watch for this class of bug again as preview dialogs grow. |
+| [030](prd/PRD-030-ai-import-diff-preview-upon-notes-import.md) | Side-by-side Baseline-vs-AI diff preview before commit, entitlement gating, confidence buckets (HIGH≥0.80/REVIEW≥0.65/LOW≥0.50), dry-run `/ai-preview` with 5-min cache, no writes until Confirm | The HIGH/REVIEW/LOW threshold vocabulary defined here becomes the standard used everywhere downstream (PRD-037, PRD-049). "No writes until confirm" is a hard rule reiterated across the import stack. |
+| [031](prd/PRD-031-ai-import-paywall-stub.md) | Paywall dialog using one real verified before/after example (not fabricated marketing copy) | Baseline import must always remain available regardless of AI entitlement — never block core functionality for monetization. |
+| [034](prd/PRD-034-import-delete-orphaned-suggestions.md) | Propagated `importRunId` into entities created via the live Suggestions panel so rollback cleans them up too | Any future "creates a note as a side effect of session editing" feature must also propagate `importRunId` or it'll leak orphans on rollback. |
+| [035](prd/PRD-035-ai-import-progress-feedback.md) | Real progress bar + phase text ("Classifying page 3 of 12...") via polling, in-memory progress store with TTL | Polling chosen over SSE deliberately for simplicity — don't over-engineer this if extending. |
+| [036](prd/PRD-036-ai-import-preview-relationships-overflow.md) | Fixed relationship-tab text overflow pushing footer buttons off-screen | Same root-cause family as PRD-018 — AI-generated text is less predictable/longer than the UI was designed for; keep defensive `break-words`/`overflow-x-hidden` habits. |
+| [042](prd/PRD-042-expandable-empty-pages-import.md) | Replaced blunt all-or-nothing empty-pages toggle with per-page checklist (`excludedEmptyPageIds`), backward-compatible with legacy boolean | Granular, reversible control over what gets imported — matches PRD-015A's safety-by-default philosophy. |
+| [044](prd/PRD-044-fix-nuclino-import-commit-error.md) | Hotfix for `importEmptyPages` scoping bug introduced by PRD-042 | The commit endpoint is a recurring fragile point when new options get bolted on — test both new and legacy code paths together. |
+| [050](prd/PRD-050-nuclino-import-link-normalization-link-evidence.md) | **(Just completed, see §5)** Link normalization, `evidenceType: "Link"` relationships at 0.90 confidence, resolution stats in preview | Closes the loop: explicit author-authored links are the *strongest* possible relationship evidence in the whole system. |
+
+**Running acceptance fixture**: nearly every import PRD (015/016/017/018/030/031) references
+the same real 105-file dataset (`Vagaries of Fate PF2e.zip`) with exact counts — if extending
+the importer, prefer testing against a real messy export over synthetic fixtures.
+
+---
+
+## 5. The 2026-07 "finish line" work: PRD-047 to PRD-050
+
+These four were the **open GitHub issues** (#1–#4) that prompted the "get note-taking across
+the finish line" request. **All four are now Done, tests passing, PR #6 open** (draft, closes
+#1–#4 on merge). Full detail in `docs/prd/PRD-047...050-*.md`; summary:
+
+- **PRD-047** (issue #1) — "Link Existing Entity" in AI Cleanup now creates a backlink with
+  visible evidence: inline snippet (~120 chars) + "Linked" state + **Undo**. Evidence window
+  is ±200 chars around the mention, not just the entity name.
+- **PRD-048** (issue #2) — Entity pages are never blank: always render Content (editable,
+  placeholder when empty), **Referenced in Sessions** (session title/snippet/date/author,
+  sorted by recency, click-to-navigate), and **Relationships** (grouped by type, confidence
+  bucket badges, DM/creator-gated delete). New entities auto-seed a `## First seen` snippet.
+- **PRD-049** (issue #3) — AI Cleanup gained a **Relationship Suggestions** section
+  (Accept persists to `noteRelationships`, Dismiss hides, disabled+explained when entities
+  aren't yet resolved) and a **Quest Promotion** flow (Create Quest seeds content + auto-links
+  QuestHasNPC/QuestAtPlace + session backlink, or Link existing quest).
+- **PRD-050** (issue #4) — Nuclino link evidence corrected: snippet is now the full markdown
+  line (not just anchor text), confidence fixed to spec's 0.90 (was 0.92), relationship
+  direction now honors the inferred `swap` (e.g. an NPC page linking a Quest correctly stores
+  the edge *from* the quest).
+
+**Deviations from the letter of the specs** (judgment calls made during implementation, worth
+knowing if revisited):
+- Backlink/relationship API paths are team-scoped (`/api/teams/:teamId/...`) rather than the
+  PRDs' literal global paths (`/api/notes/:id/...`) — functionally equivalent, consistent with
+  the rest of the app's routing convention.
+- PRD-047's dedup key includes the evidence-block hash, so the same (session, entity) pair
+  with *different* snippets produces grouped, bounded rows rather than one row per pair
+  regardless of evidence — this matches the PRD's own suggested alternative option.
+  don't rewrite the target page's anchor text to canonical title on Nuclino link resolution
+  (kept the author's original anchor text) — judged more respectful of authorial voice,
+  consistent with PRD-016's explicit non-goal of "rewriting user content."
+
+---
+
+## 6. AI classification quality/trust/cost pipeline (PRD-027–029, 033, 037–041, 043, 045–046)
+
+This is the **supporting infrastructure** the live editor (§3) and importer (§4) both lean on
+for entity/relationship typing. All Done.
+
+**The monetization pivot**: PRD-027 originally designed a team-wide, subscription-gated AI
+paywall with pricing tiers. PRD-028 immediately reversed this to a free, per-member opt-in
+toggle instead ("every user controls their own AI subscription") — a deliberate move away from
+monetization-first gating toward maximizing adoption. PRD-029 then fixed the toggle's initial
+breakage (backend PATCH endpoint silently dropped the new field).
+
+**The "Needs Review" panel** — a durable, evolving UI surface (not a one-time import warning):
+- PRD-037 introduced it (0.65 confidence threshold, count badge, click-to-navigate)
+- PRD-038 added inline Approve/Reject/Reclassify + surfaced the AI's own explanation text
+- PRD-041 added consistent colored type badges
+- PRD-045 fixed a missing "Point of Interest" reclassify option (AI-inferrable types are
+  deliberately narrower than human-assignable types — POI is human-only)
+- PRD-046 fixed item-click not syncing the right-hand detail panel
+
+**Recurring bug family to watch for**: enum/type-vocabulary drift across layers that are just
+string literals duplicated in multiple files (PRD-029's PATCH field whitelist, PRD-039's
+prompt-vocabulary mismatch, PRD-045's dropdown/backend/mapping-table gaps). If a "type" or
+"field" concept exists in more than one file (prompt text, validation array, mapping table,
+frontend enum), expect this bug class to recur — a single source of truth would prevent it.
+
+**Cost & robustness infrastructure**:
+- PRD-033 — three rounds of hardening `extractJsonFromResponse`/`repairJson` against
+  malformed Claude JSON output (preambles, trailing commas, unescaped quotes, literal
+  newlines). Treat "the model won't always emit valid JSON" as permanent, not a one-off fix.
+- PRD-040 — analytical PRD reducing needs-review rate via cheap heuristics (title patterns,
+  PC-name context, code-side index-note detection) rather than a costlier two-pass AI call —
+  explicitly rejected doubling API cost.
+- PRD-043 — persistent DB-backed AI result cache (content-hash + algorithm-version keyed,
+  team-scoped, 30-day TTL, CLI-only admin tool for app-store security reasons). Iterated twice
+  post-launch to fix a caching gap between the enrichment worker and the AI-preview endpoint,
+  and to add negative-caching for "no relationship found" results.
+
+---
+
+## 7. Explicitly out of scope for note-taking (exists, but is a different subsystem)
+
+These PRDs are real and mostly Done, but govern **scheduling/availability/calendar**, not
+note-taking — don't conflate them when reasoning about "the notes system":
+
+PRD-007 (setup wizard), PRD-009/009A (availability creation/labels), PRD-010/010A/010B
+(upcoming-sessions eligibility/DM controls), PRD-011 (view team availability), PRD-012
+(multi-month upcoming sessions), PRD-013 (DM calendar cancel), PRD-014 (conditional info icon).
+
+Also out of scope: **PRD-020/032** (settings-screen bug fix + auto-save — general app
+polish, not note-specific), and **GitHub issue #5** ("Replace remaining Quest Keeper
+branding with Helm" — stale branding cleanup in `client/index.html` and
+`client/src/pages/join-team.tsx`, still open, not note-taking).
+
+---
+
+## 8. Design principles worth reusing verbatim (cheat sheet)
+
+When building the *next* note-taking feature, these are the load-bearing principles that
+recur across 3+ independent PRDs — treat deviations from them as a deliberate, flagged choice:
+
+1. **Suggest, don't assume.** No feature should auto-create or auto-link an entity/relationship
+   without an explicit user action. (PRD-002, 006, 016, 022, 049)
+2. **Session-first, structure-later.** Never require a structural decision at the moment of
+   capture. (PRD-001, 004, 008, 019)
+3. **Evidence/traceability everywhere.** Every entity, relationship, and backlink should be
+   traceable to the exact source text (snippet + offsets) that justified it. (PRD-005, 006,
+   016, 030, 047, 048, 049, 050)
+4. **Three-tier confidence vocabulary**: HIGH (≥0.80, auto-approvable) / REVIEW (0.65–0.79,
+   "needs review") / LOW (0.50–0.64, de-emphasized). Established in PRD-006/030/037, reused
+   through PRD-049. Use these exact thresholds unless a PRD explicitly changes them.
+5. **Deterministic/structural signals outrank probabilistic AI signals.** Explicit links,
+   collection membership, and user confirmations are "ground truth"; AI output is always a
+   suggestion subject to review and never silently overrides them. (PRD-016, 017, 030)
+6. **No database writes until explicit confirmation** for anything AI-assisted or bulk
+   (diff previews, import commits). Reversibility (rollback/undo) is a first-class
+   requirement, not an afterthought. (PRD-015A, 030, 031, 047's Undo)
+7. **Zero perceptible typing-latency.** Background/debounced/web-worker processing only;
+   live-play capture is sacrosanct. (PRD-001, 002, 022)
+8. **Session-scoped, non-persisted dismissal state.** Rejecting a suggestion shouldn't be a
+   permanent DB write — scope it to the session/localStorage so it doesn't nag but also
+   doesn't require a schema migration to "undo" a dismissal. (PRD-002, 003, 006, 022)
+9. **Never let AI/paywall gating block core functionality.** Baseline capture and baseline
+   import must always work regardless of AI entitlement state. (PRD-027–031)
+10. **Test against real, messy content — not synthetic fixtures.** The entity-detection
+    genre-tuning (PRD-024/025) and the recurring `Vagaries of Fate PF2e.zip` import fixture
+    both reflect this. Prefer it when adding new detection/classification logic.
+
+---
+
+## 9. Open threads / things to verify if picking this back up
+
+- **PRD-023's optional phases**: a DB-level partial unique index on
+  `(team_id, DATE(session_date))` for session logs, and a one-time production duplicate-row
+  cleanup query, were marked optional/Phase 2-3 — confirm whether these ever landed, since
+  they're the "defense in depth" half of the fix (server-side idempotency, Phase 1, is done).
+- **GitHub issue #5** (Quest Keeper branding) is still open and unrelated to note-taking —
+  quick two-file fix if picked up next.
+- **PR #6** (closes issues #1–#4 / PRD-047–050) is open as a draft; being watched via an
+  hourly self-check-in until merged or closed.
+- This file was synthesized from PRD docs only; it does not re-verify current code state
+  against every claim above (that level of audit was done specifically for PRD-047–050 in
+  PR #6, not for the earlier PRDs assumed Done in this pass).

--- a/docs/prd/PRD-001-session-logs.md
+++ b/docs/prd/PRD-001-session-logs.md
@@ -165,3 +165,17 @@ interface ContentBlock {
 1. Should session logs support collaborative editing (multiple authors same session)?
 2. Should we support merging multiple session logs from the same date?
 3. Rich text formatting requirements (bold, italic, headers)?
+
+
+---
+
+## Amendment (2026-07-06) — offset-based traceability supersedes the block substrate
+
+FR-3's `ContentBlock[]` storage shipped at the schema/API level but the production editor
+captures plain text; real sessions have `contentBlocks: null`. Per the done-ness report
+(P2-2 decision), per-block traceability is formally superseded by an **offset-based model**:
+backlinks store snippet + start/end character offsets into the note's plain-text content
+(PRD-047), reference navigation scrolls to and selects the mention via those offsets
+(PRD-005 amendment), and offsets/snippets are re-indexed on content edits
+(`server/backlink-reindex.ts`). The `contentBlocks` column remains for API compatibility
+but is no longer the planned substrate.

--- a/docs/prd/PRD-004-quest-status-progression.md
+++ b/docs/prd/PRD-004-quest-status-progression.md
@@ -228,3 +228,16 @@ const statusFilters = ['all', 'lead', 'todo', 'active', 'done', 'abandoned'];
 2. Should there be XP or completion rewards tied to quest status?
 3. Should "done" quests require completion notes or stay optional?
 4. Allow custom statuses beyond the five defined?
+
+
+---
+
+## Amendment (2026-07-06) — status visibility shipped; strict transitions intentionally omitted
+
+FR-5's user-facing surface now exists: quest rows in the Notes left panel show a colored
+status badge, the Quests section has status filter chips (All/Lead/To Do/Active/Done/
+Abandoned), the hover preview shows status, and new quests default to `lead` in the shared
+create handler (production parity with the test storage). The strict FR-2 transition graph
+(e.g. rejecting lead→done) is deliberately NOT enforced — a hard state machine conflicts
+with the capture-first philosophy (roadmap §8); revisit only if invalid jumps cause real
+problems.

--- a/docs/prd/PRD-005-backlinks.md
+++ b/docs/prd/PRD-005-backlinks.md
@@ -246,3 +246,21 @@ For performance with large session histories:
 2. Should we show a "mentioned in X sessions" summary on entity cards in lists?
 3. How to handle backlinks when entities are merged?
 4. Should there be a graph visualization of entity relationships via backlinks?
+
+
+---
+
+## Amendment (2026-07-06) — FR-3/FR-4 delivered via the offset-based model
+
+- FR-3 (navigate to referenced block + highlight): clicking a "Referenced in Sessions"
+  entry opens the source note and scrolls to/selects the exact mention using the
+  backlink's stored start/end offsets (text selection serves as the highlight in the
+  plain-text editor). Implemented in `note-detail-sections.tsx` → `notes.tsx` →
+  `notes-editor-panel.tsx`.
+- FR-4 (backlinks reflect current state): on any content edit, outgoing backlinks are
+  re-anchored by `server/backlink-reindex.ts` (shared PATCH handler): exact snippet found →
+  offsets refreshed; snippet gone but target title still mentioned → snippet rebuilt around
+  the title; mention entirely gone → backlink removed. Unit tests in
+  `server/backlink-reindex.test.ts`.
+- The `?block=:blockId` deep-link pattern from the original spec is superseded by the
+  offset mechanism (see PRD-001 amendment).

--- a/docs/prd/PRD-047-session-ai-cleanup-link-existing-entity-backlinks.md
+++ b/docs/prd/PRD-047-session-ai-cleanup-link-existing-entity-backlinks.md
@@ -1,0 +1,41 @@
+# PRD-047 — Session AI Cleanup: Make "Link Existing Entity" Create Backlinks + Visible Evidence
+
+GitHub issue: #1
+
+## Summary
+In the Session Notes AI Cleanup panel, clicking **Link** on an existing entity creates a
+persistent backlink (session note → entity note) with evidence snippets, shows an inline
+"Linked" state with the snippet, and offers **Undo**.
+
+## Functional Requirements
+- **FR-1** Link creates a backlink record with `textSnippet` (bounded ±200-char evidence
+  window), offsets, `evidenceType: "Mention"`, and HIGH confidence (0.8) for
+  user-confirmed links.
+- **FR-2** The panel shows a "Linked" state immediately with the evidence snippet
+  truncated to ~120 chars inline; the row stays visible and non-actionable.
+- **FR-3** Undo removes the backlink and reverts the row to actionable.
+- **FR-4** API: `POST /api/teams/:teamId/notes/:noteId/backlinks` and
+  `DELETE /api/teams/:teamId/backlinks/:backlinkId` with auth + team membership checks;
+  delete allowed for creator, source-note author, or DM.
+- **FR-5** De-duplication: repeat links with the same evidence upsert into one record via
+  canonicalized `sourceBlockId` hashing.
+
+## Status
+Done
+
+## Implementation Notes
+- Modified: `client/src/components/notes/entity-suggestion-card.tsx` (Linked state +
+  inline snippet + Undo button, `truncateSnippet` at 120 chars),
+  `client/src/components/notes/entity-suggestions-panel.tsx` (captures created backlink
+  id/snippet, `handleUndoLink`, ±200-char `extractEvidenceSnippet` for all backlinks),
+  `client/src/hooks/use-suggestion-persistence.ts` (`unmarkCreated` for undo).
+- Server endpoints, dedupe upsert, and delete authorization already existed
+  (`server/routes.ts`); endpoint paths are team-scoped variants of the PRD's paths
+  (functionally equivalent).
+- Deviation: dedupe key includes the evidence-block hash, so the same (session, entity)
+  pair with *different* snippets produces grouped, bounded rows (per FR-5's "allow
+  multiple if offsets differ" option).
+- Tests: `client/src/components/notes/entity-suggestions-panel.test.tsx`
+  ("link existing entity (PRD-047)" — link + snippet + undo flows),
+  `server/cleanup-suggestions.api.test.ts` (backlink upsert idempotency, delete
+  authorization branches: creator OK, DM OK, other member 403).

--- a/docs/prd/PRD-048-entity-pages-content-references-relationships.md
+++ b/docs/prd/PRD-048-entity-pages-content-references-relationships.md
@@ -1,0 +1,45 @@
+# PRD-048 — Entity Pages: Show Content + Session References + Relationships
+
+GitHub issue: #2
+
+## Summary
+Entity pages (NPC/Area/Quest/POI/…) are never blank: they always show an editable
+Content section, a "Referenced in Sessions" section (backlinks with snippets, session
+date, author), and a "Relationships" section (grouped by type with evidence + confidence
+buckets and role-gated deletion). New entities created from session AI Cleanup are seeded
+with a "First seen" snippet.
+
+## Functional Requirements
+- **FR-1** Entity detail view shows 3 sections with informative empty states:
+  Content (editable, instructional placeholder), Referenced in Sessions, Relationships.
+- **FR-2** Session references come from backlinks (`toNoteId = entity`), ordered by most
+  recent session date, showing session title, snippet, date, and author.
+- **FR-3** Relationships are grouped by type (QuestHasNPC/QuestAtPlace/NPCInPlace/Related)
+  with evidence type + HIGH/REVIEW/LOW confidence bucket; DM or creator can delete.
+- **FR-4** Entities created from session AI Cleanup seed content with
+  `## First seen\n- Session <date>: "<snippet>"` (only when content would be empty).
+- **FR-5** Clicking a session reference navigates to that session note in the editor,
+  preserving team context.
+
+## Status
+Done
+
+## Implementation Notes
+- Added: `client/src/components/notes/note-detail-sections.tsx` (references +
+  relationships sections, empty states, delete relationship, navigation).
+- Modified: `client/src/components/notes/notes-editor-panel.tsx` (renders detail sections
+  for non-session notes; entity placeholder text), `client/src/pages/notes.tsx` (passes
+  member role), `server/routes.ts` + `server/test/test-routes.ts` detail endpoint
+  (adds `sourceNoteSessionDate`, `createdByName`, session-recency sort),
+  `shared/cleanup-suggestions.ts` (`buildFirstSeenSeed`),
+  `client/src/components/notes/entity-suggestions-panel.tsx` (seeds new entity content
+  on Accept / bulk accept / quest promotion).
+- Detail data comes from the existing `GET /api/teams/:teamId/notes/:noteId` endpoint
+  (PRD's `/detail` equivalent), feature-flagged by `ENABLE_ENTITY_DETAIL_ENDPOINT`
+  (default on). Confidence buckets are computed client-side with the shared
+  `confidenceBucket` helper.
+- Tests: `client/src/components/notes/note-detail-sections.test.tsx` (empty states,
+  reference rendering + navigation, grouping/bucket labels, delete gating for
+  creator/DM/other), `server/cleanup-suggestions.api.test.ts` (session-date ordering +
+  author names, private-note redaction, quest detail integration),
+  `shared/cleanup-suggestions.test.ts` (`buildFirstSeenSeed`).

--- a/docs/prd/PRD-049-session-ai-cleanup-relationships-quest-promotion.md
+++ b/docs/prd/PRD-049-session-ai-cleanup-relationships-quest-promotion.md
@@ -1,0 +1,48 @@
+# PRD-049 — Session AI Cleanup: Persist Relationships + Quest Promotion From Actionable Text
+
+GitHub issue: #3
+
+## Summary
+The AI Cleanup panel surfaces a **Relationship Suggestions** section (entity pair, type,
+evidence, confidence bucket, snippet, Accept/Dismiss) and a **Quest Promotion** section
+generated from actionable text ("Find/Defeat/Retrieve …"). Accepting persists rows in
+`noteRelationships`; promoting creates a seeded Quest note auto-linked to its NPC giver
+and Area with a session backlink.
+
+## Functional Requirements
+- **FR-1** Relationship Suggestions section below New/Existing Entities with
+  A → B, relationship type, evidence type, confidence score + bucket, snippet, and
+  Accept/Dismiss actions. Sourced from proximity heuristics
+  (`shared/proximity-suggestions.ts`) via `buildCleanupSuggestions`.
+- **FR-2** Accept persists to `noteRelationships` (from/to note ids, type, evidence,
+  confidence, snippet, creator); survives refresh and appears on entity pages (PRD-048).
+- **FR-3** Quest Promotion: proposed title + snippet + suggested NPC/Area; actions are
+  Create new Quest (seeded content, QuestHasNPC/QuestAtPlace relationships, session
+  backlink), Link existing quest, or Dismiss.
+- **FR-4** Linking/accepting entities refreshes relationship suggestions without a page
+  reload (suggestions re-fetch after link/accept/promote actions).
+- **FR-5** Confidence buckets: HIGH ≥ 0.80, REVIEW 0.65–0.79, LOW < 0.65; LOW suggestions
+  are visually de-emphasized.
+
+## Status
+Done
+
+## Implementation Notes
+- Added: `client/src/components/notes/relationship-suggestions-section.tsx`,
+  `client/src/components/notes/quest-promotion-section.tsx`.
+- Modified: `client/src/components/notes/entity-suggestions-panel.tsx` (stores the full
+  cleanup response, accept/dismiss relationship handlers, quest create/link/dismiss
+  handlers, suggestion refresh after actions), `shared/cleanup-suggestions.ts`
+  (exported `confidenceBucket`).
+- Suggestion generation, deterministic ids, quest pattern detection, and the
+  `GET/POST /api/teams/:teamId/session-logs/:noteId/cleanup-suggestions`,
+  `POST/DELETE /api/teams/:teamId/relationships` endpoints already existed on this
+  branch; this PRD completes the missing UI and persistence flows.
+- Accept is disabled (with explanation) for suggestions whose entities are not yet
+  linked to notes (`requiresResolution`); linking the entities and refreshing enables it.
+- Tests: `shared/cleanup-suggestions.test.ts` (bucket thresholds, relationship type
+  inference incl. swap, suggestion pairs, quest detection + nearest NPC/Area, existing
+  quest matching, determinism), `client/src/components/notes/cleanup-sections.test.tsx`
+  (both sections: rendering, callbacks, disabled/accepted/dismissed states),
+  `server/cleanup-suggestions.api.test.ts` (relationship provenance + idempotency,
+  delete role gating, quest-promotion end-to-end flow verified on quest detail).

--- a/docs/prd/PRD-050-nuclino-import-link-normalization-link-evidence.md
+++ b/docs/prd/PRD-050-nuclino-import-link-normalization-link-evidence.md
@@ -1,0 +1,44 @@
+# PRD-050 — Nuclino Import: Normalize Internal Links + Use Link Evidence for Relationships
+
+GitHub issue: #4
+
+## Summary
+Nuclino internal links (`[Text](<Some Page abcdef12.md?n>)`) are normalized reliably,
+resolved deterministically by source page id, and turned into high-confidence
+relationship evidence (`evidenceType: "Link"`, confidence 0.90) on commit. The import
+preview shows link resolution stats (resolved/unresolved counts + top unresolved
+targets).
+
+## Functional Requirements
+- **FR-1** Normalization strips `<>` and `?n`, trims, URL-decodes, and extracts the
+  8-hex `sourcePageId`; no normalized target contains `<`, `>`, or `?n`.
+- **FR-2** `sourcePageId → noteId` map resolves links deterministically; unresolved links
+  are tracked as warnings.
+- **FR-3** Resolved links create `noteRelationships` rows with `evidenceType: "Link"`,
+  confidence 0.90, snippet = the markdown line containing the link (truncated), and
+  inferred type (QuestHasNPC/QuestAtPlace/NPCInPlace/Related) with canonical direction.
+- **FR-4** Link anchor text never creates duplicate notes; re-import of the same zip is
+  stable (existing notes updated by `sourcePageId`).
+- **FR-5** Import preview shows total/resolved/unresolved link counts and up to 10
+  top unresolved targets.
+
+## Status
+Done
+
+## Implementation Notes
+- Modified: `shared/nuclino-parser.ts` (`NuclinoLink.lineSnippet` captures the containing
+  markdown line truncated to 240 chars; `summarizeNuclinoLinks` now reports
+  `resolvedLinks`, `unresolvedLinks`, `topUnresolvedTargets`), `server/routes.ts` commit
+  path (confidence 0.90 constant, line snippet as evidence, honors the inferred `swap`
+  direction so e.g. an NPC page linking a Quest stores QuestHasNPC from the quest),
+  `client/src/components/nuclino-import-dialog.tsx` (resolution stats + unresolved
+  targets panel in the preview).
+- Deviation: resolved links keep the author's anchor text when rewritten to
+  `/notes/:id` (canonical titles are used for the notes themselves; rewriting anchor
+  text was judged user-hostile and is not required by the acceptance criteria).
+- Behind the existing `ENABLE_NUCLINO_LINK_EVIDENCE` feature flag (default on); when
+  off, link evidence is stored as backlinks instead of relationships.
+- Tests: `shared/nuclino-parser.test.ts` (line snippet extraction + truncation,
+  normalization invariant over adversarial inputs, resolution stats + top-10 cap),
+  `shared/cleanup-suggestions.test.ts` (relationship type inference incl. swap cases
+  used by the commit path).

--- a/docs/prd/README.md
+++ b/docs/prd/README.md
@@ -15,6 +15,15 @@ These PRDs implement the "session-first, structure-later" note-taking system des
 | [PRD-005](PRD-005-backlinks.md) | Backlinks | 🔴 To Do | P1 | PRD-001 |
 | [PRD-006](PRD-006-proximity-suggestions.md) | Proximity Suggestions | 🔴 To Do | P2 | PRD-002 |
 
+### Note-Taking Completion (Issues #1-#4)
+
+| PRD | Feature | Status |
+|-----|---------|--------|
+| [PRD-047](PRD-047-session-ai-cleanup-link-existing-entity-backlinks.md) | Link Existing Entity → Backlinks + Evidence | 🟢 Done |
+| [PRD-048](PRD-048-entity-pages-content-references-relationships.md) | Entity Pages: Content + References + Relationships | 🟢 Done |
+| [PRD-049](PRD-049-session-ai-cleanup-relationships-quest-promotion.md) | Persist Relationships + Quest Promotion | 🟢 Done |
+| [PRD-050](PRD-050-nuclino-import-link-normalization-link-evidence.md) | Nuclino Link Normalization + Link Evidence | 🟢 Done |
+
 ### Status Legend
 - 🔴 To Do - Not started
 - 🟡 In Progress - Implementation underway

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,6 +73,7 @@
         "react-dom": "^18.3.1",
         "react-hook-form": "^7.55.0",
         "react-icons": "^5.4.0",
+        "react-markdown": "^10.1.0",
         "react-resizable-panels": "^2.1.7",
         "recharts": "^2.15.2",
         "supertest": "^7.1.4",
@@ -253,7 +254,6 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -609,7 +609,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -653,7 +652,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3333,7 +3331,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -3490,6 +3489,15 @@
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
       "license": "MIT"
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -3501,6 +3509,15 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
     },
     "node_modules/@types/express": {
       "version": "4.17.21",
@@ -3536,11 +3553,29 @@
         "@types/express": "*"
       }
     },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/http-errors": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
       "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
       "license": "MIT"
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
     },
     "node_modules/@types/memoizee": {
       "version": "0.4.12",
@@ -3558,6 +3593,12 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
     "node_modules/@types/multer": {
@@ -3617,7 +3658,6 @@
       "integrity": "sha512-/2WmmBXHLsfRqzfHW7BNZ8SbYzE8OSk7i3WjFYvfgRHj7S1xj+16Je5fUKv3lVdVzk/zn9TXOqf+avFCFIE0yQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "pg-protocol": "*",
@@ -3628,7 +3668,6 @@
       "version": "15.7.13",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.13.tgz",
       "integrity": "sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/qs": {
@@ -3647,9 +3686,7 @@
       "version": "18.3.12",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.12.tgz",
       "integrity": "sha512-D2wOSq/d6Agt28q7rSI3jhU7G6aiuzljDGZ2hTZHIkrTLUI+AF3WMeKkEZ9nN2fkBAlcktT6vcZjDFiIhMYEQw==",
-      "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -3661,7 +3698,6 @@
       "integrity": "sha512-qW1Mfv8taImTthu4KoXgDfLuk4bydU6Q/TkADnDWWHwi4NX4BR+LWfTp2sVmTqRrsHvyDDTelgelxJ+SsejKKQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -3709,6 +3745,12 @@
         "@types/superagent": "^8.1.0"
       }
     },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
     "node_modules/@types/ws": {
       "version": "8.5.13",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.13.tgz",
@@ -3718,6 +3760,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.2.tgz",
+      "integrity": "sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA==",
+      "license": "ISC"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
@@ -4066,6 +4114,16 @@
         "postcss": "^8.1.0"
       }
     },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -4174,7 +4232,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001669",
         "electron-to-chromium": "^1.5.41",
@@ -4193,6 +4250,20 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "license": "MIT"
+    },
+    "node_modules/bufferutil": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.1.0.tgz",
+      "integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
     },
     "node_modules/busboy": {
       "version": "1.6.0",
@@ -4276,6 +4347,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -4283,6 +4364,46 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/chokidar": {
@@ -4383,6 +4504,16 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/commander": {
@@ -4729,7 +4860,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
       "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -4764,6 +4894,19 @@
       "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
       "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
@@ -4804,7 +4947,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4834,6 +4976,19 @@
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
     },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/dezalgo": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
@@ -4861,7 +5016,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -5410,7 +5566,6 @@
       "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.39.3.tgz",
       "integrity": "sha512-EZ8ZpYvDIvKU9C56JYLOmUskazhad+uXZCTCRN4OnRMsL+xAJ05dv1eCpAG5xzhsm1hqiuC5kAZUCS924u2DTw==",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "@aws-sdk/client-rds-data": ">=3",
         "@cloudflare/workers-types": ">=4",
@@ -5569,8 +5724,7 @@
     "node_modules/embla-carousel": {
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
-      "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "peer": true
+      "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA=="
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -5744,7 +5898,6 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -5822,6 +5975,16 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/estree-walker": {
@@ -5985,6 +6148,12 @@
       "dependencies": {
         "type": "^2.7.2"
       }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
     },
     "node_modules/fast-equals": {
       "version": "5.2.2",
@@ -6392,6 +6561,46 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
@@ -6410,6 +6619,16 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "license": "MIT"
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/http-errors": {
       "version": "2.0.0",
@@ -6483,6 +6702,12 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
     "node_modules/input-otp": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/input-otp/-/input-otp-1.4.2.tgz",
@@ -6510,6 +6735,30 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -6535,6 +6784,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-extglob": {
@@ -6567,6 +6826,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -6574,6 +6843,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -6690,7 +6971,6 @@
       "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.28",
         "@asamuzakjp/dom-selector": "^6.7.6",
@@ -7058,6 +7338,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -7103,6 +7393,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -7161,6 +7452,159 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/mdn-data": {
@@ -7253,6 +7697,448 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -7597,6 +8483,31 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
     "node_modules/parse5": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
@@ -7715,7 +8626,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
       "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",
@@ -7970,7 +8880,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -8151,6 +9060,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -8166,6 +9076,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -8176,6 +9087,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -8188,7 +9100,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -8204,6 +9117,16 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -8307,7 +9230,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -8333,7 +9255,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -8346,7 +9267,6 @@
       "version": "7.55.0",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.55.0.tgz",
       "integrity": "sha512-XRnjsH3GVMQz1moZTW53MxfoWN7aDpUg/GpVNc4A3eXRVNdGXfbzJ4vM4aLQ8g6XCUh1nIbx70aaNCl7kxnjog==",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -8372,6 +9292,33 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "license": "MIT"
+    },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -8579,6 +9526,39 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/require-from-string": {
@@ -8902,6 +9882,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/split2": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
@@ -9008,6 +9998,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
@@ -9056,6 +10060,24 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
       }
     },
     "node_modules/sucrase": {
@@ -9169,7 +10191,6 @@
       "version": "3.4.17",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
       "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -9317,7 +10338,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9401,6 +10421,26 @@
         "node": ">=20"
       }
     },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/ts-algebra": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
@@ -9425,7 +10465,6 @@
       "integrity": "sha512-+wKjMNU9w/EaQayHXb7WA7ZaHY6hN8WgfvHNQ3t1PnU91/7O8TcTnIhCDYTZwnt8JsO9IBqZ30Ln1r7pPF52Aw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.25.0",
         "get-tsconfig": "^4.7.5"
@@ -9504,6 +10543,93 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
+    },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
@@ -9631,6 +10757,34 @@
         "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/victory-vendor": {
       "version": "36.9.2",
       "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
@@ -9658,7 +10812,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.0.tgz",
       "integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -10207,7 +11360,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10220,7 +11372,6 @@
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.16.tgz",
       "integrity": "sha512-E4t7DJ9pESL6E3I8nFjPa4xGUd3PmiWDLsDztS2qXSJWfHtbQnwAWylaBvSNY48I3vr8PTqIZlyK8TE3V3CA4Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.16",
         "@vitest/mocker": "4.0.16",
@@ -10565,7 +11716,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -10580,6 +11730,16 @@
       },
       "peerDependencies": {
         "zod": "^3.18.0"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.55.0",
     "react-icons": "^5.4.0",
+    "react-markdown": "^10.1.0",
     "react-resizable-panels": "^2.1.7",
     "recharts": "^2.15.2",
     "supertest": "^7.1.4",

--- a/server/ai/ai-cache.test.ts
+++ b/server/ai/ai-cache.test.ts
@@ -244,6 +244,118 @@ describe("AI Cache", () => {
     });
   });
 
+  describe("Relationship Cache Operations", () => {
+    const teamId = "team-123";
+
+    // P0-3 regression: setRelationship used to store only a 100-char content
+    // prefix (_cachedFromContent) while getRelationship compared against the
+    // full normalized content hash, so for any note longer than 100 chars the
+    // hashes never matched and cached directional relationships were returned
+    // reversed. The fix stores _cachedFromKeyHash (the full normalized hash,
+    // computed with the same function the getter uses). The legacy
+    // title/content-prefix fallback was intentionally NOT kept: the fix also
+    // bumps the relationship algorithm version to 1.1.0, and since the version
+    // is part of the cache lookup key, old 1.0.0 entries can never be loaded —
+    // making a fallback dead code and the version bump the simpler safe choice.
+    const longNoteA: NoteWithClassification = {
+      id: "note-quest",
+      title: "The Sunken Crown",
+      content:
+        "The party has been tasked with recovering the Sunken Crown from the " +
+        "flooded ruins beneath Lake Veyra. The crown once belonged to the " +
+        "drowned king Aldemar, and local legends claim it grants dominion over " +
+        "the waters. Captain Garner warned them about the cultists who guard " +
+        "the ruins and the strange lights seen beneath the surface at night.",
+      inferredType: "Quest",
+      internalLinks: [],
+    };
+
+    const longNoteB: NoteWithClassification = {
+      id: "note-npc",
+      title: "Captain Garner",
+      content:
+        "A grizzled veteran who commands the town guard of Veyra's Rest. " +
+        "Garner lost his left eye during the border wars and wears a bronze " +
+        "patch etched with the sigil of his old regiment. He distrusts " +
+        "adventurers but pays well for information about the cult activity " +
+        "near the lake, and he keeps a detailed ledger of every stranger who " +
+        "passes through the town gates.",
+      inferredType: "NPC",
+      internalLinks: [],
+    };
+
+    const directionalResult: RelationshipResult = {
+      fromNoteId: "note-quest",
+      toNoteId: "note-npc",
+      relationshipType: "QuestHasNPC",
+      confidence: 0.9,
+      evidenceSnippet: "Captain Garner warned them about the cultists",
+      evidenceType: "Mention",
+    };
+
+    it("returns null for cache miss", async () => {
+      const result = await cache.getRelationship(longNoteA, longNoteB, teamId);
+      expect(result).toBeNull();
+    });
+
+    it("preserves direction for long notes when lookup order matches stored order", async () => {
+      // Both notes have >200 chars of content, which broke the old
+      // prefix-based direction check and caused an unconditional swap.
+      expect(longNoteA.content.length).toBeGreaterThan(200);
+      expect(longNoteB.content.length).toBeGreaterThan(200);
+
+      await cache.setRelationship(longNoteA, longNoteB, directionalResult, teamId);
+
+      const result = await cache.getRelationship(longNoteA, longNoteB, teamId);
+
+      expect(result).not.toBeNull();
+      expect(result?.relationshipType).toBe("QuestHasNPC");
+      // Direction must NOT be swapped: A was the "from" side when stored
+      expect(result?.fromNoteId).toBe(longNoteA.id);
+      expect(result?.toNoteId).toBe(longNoteB.id);
+    });
+
+    it("maps direction back to stored order when lookup order is reversed", async () => {
+      await cache.setRelationship(longNoteA, longNoteB, directionalResult, teamId);
+
+      // Look up with (B, A) — the order-independent pair hash still hits,
+      // and the direction must map back to A->B via the caller's note ids
+      const result = await cache.getRelationship(longNoteB, longNoteA, teamId);
+
+      expect(result).not.toBeNull();
+      expect(result?.relationshipType).toBe("QuestHasNPC");
+      expect(result?.fromNoteId).toBe(longNoteA.id);
+      expect(result?.toNoteId).toBe(longNoteB.id);
+    });
+
+    it("maps to current note ids when notes are re-imported with new ids", async () => {
+      await cache.setRelationship(longNoteA, longNoteB, directionalResult, teamId);
+
+      const reimportedA = { ...longNoteA, id: "note-quest-v2" };
+      const reimportedB = { ...longNoteB, id: "note-npc-v2" };
+
+      const result = await cache.getRelationship(reimportedA, reimportedB, teamId);
+
+      expect(result).not.toBeNull();
+      expect(result?.fromNoteId).toBe("note-quest-v2");
+      expect(result?.toNoteId).toBe("note-npc-v2");
+    });
+
+    it("misses cache when team ID differs", async () => {
+      await cache.setRelationship(longNoteA, longNoteB, directionalResult, teamId);
+      const result = await cache.getRelationship(longNoteA, longNoteB, "different-team");
+      expect(result).toBeNull();
+    });
+
+    it("does not leak direction metadata in the returned result", async () => {
+      await cache.setRelationship(longNoteA, longNoteB, directionalResult, teamId);
+      const result = await cache.getRelationship(longNoteA, longNoteB, teamId);
+
+      expect(result).not.toBeNull();
+      expect(result).not.toHaveProperty("_cachedFromKeyHash");
+    });
+  });
+
   describe("Invalidation", () => {
     const teamId = "team-123";
     const pcNames: string[] = [];

--- a/server/ai/ai-cache.ts
+++ b/server/ai/ai-cache.ts
@@ -284,19 +284,22 @@ export class AICache {
     // Increment hit count
     this.storage.incrementAICacheHitCount(entry.id).catch(() => {});
 
-    // Map cached result to match current note IDs
-    const result = entry.result as RelationshipResult;
+    // Map cached result to match current note IDs.
+    // Relationships are order-dependent, but our cache key is order-independent.
+    // The entry stores _cachedFromKeyHash: the full normalized content hash of
+    // the note that was the "from" side when the result was cached. Comparing
+    // the caller's fromNote hash against it tells us whether to keep or swap
+    // the direction. (No legacy fallback is needed: entries written before
+    // _cachedFromKeyHash existed carry algorithm version 1.0.0 and can never
+    // be returned under the current version.)
+    const { _cachedFromKeyHash, ...result } = entry.result as RelationshipResult & {
+      _cachedFromKeyHash?: string;
+    };
 
-    // Relationships are order-dependent, but our cache key is order-independent
-    // We need to return the relationship with correct from/to based on input order
-    const cachedHash1 = sha256(normalizeForHash(fromNote.title, fromNote.content));
-    const cachedFromHash = sha256(normalizeForHash(
-      (result as any)._cachedFromTitle || "",
-      (result as any)._cachedFromContent || ""
-    ));
+    const callerFromHash = sha256(normalizeForHash(fromNote.title, fromNote.content));
 
-    // If the from note matches, return as-is; otherwise swap
-    if (cachedHash1 === cachedFromHash) {
+    // If the from note matches the cached direction, return as-is; otherwise swap
+    if (callerFromHash === _cachedFromKeyHash) {
       return {
         ...result,
         fromNoteId: fromNote.id,
@@ -325,11 +328,14 @@ export class AICache {
 
     const expiresAt = new Date(Date.now() + DEFAULT_CACHE_TTL_MS);
 
-    // Store with metadata to preserve direction
+    // Store with metadata to preserve direction. The key hash is the FULL
+    // normalized content hash (same function getRelationship uses for the
+    // caller's fromNote), so direction detection is exact. Storing a content
+    // prefix and re-hashing it on read (the old approach) broke for any note
+    // whose normalized content exceeded the prefix length.
     const resultWithMeta = {
       ...result,
-      _cachedFromTitle: fromNote.title,
-      _cachedFromContent: fromNote.content.slice(0, 100), // Just enough to identify
+      _cachedFromKeyHash: sha256(normalizeForHash(fromNote.title, fromNote.content)),
     };
 
     const entry: InsertAICacheEntry = {

--- a/server/ai/cache-versions.ts
+++ b/server/ai/cache-versions.ts
@@ -23,12 +23,24 @@ export const AI_ALGORITHM_VERSIONS = {
     ],
   },
   relationship: {
-    current: "1.0.0",
+    // 1.1.0: cached relationship entries now store _cachedFromKeyHash (full
+    // normalized content hash of the "from" note) instead of a 100-char
+    // content prefix. The old prefix-based direction check could never match
+    // notes longer than 100 chars, causing cached directional relationships
+    // to be returned reversed. Bumping the version invalidates all 1.0.0
+    // entries so getRelationship never sees an entry without _cachedFromKeyHash.
+    current: "1.1.0",
     history: [
       {
         version: "1.0.0",
         date: "2026-01-19",
         description: "Initial caching implementation with order-independent pair hashing",
+      },
+      {
+        version: "1.1.0",
+        date: "2026-07-06",
+        description:
+          "Store full normalized from-note hash (_cachedFromKeyHash) for direction detection; fixes reversed directions for notes >100 chars",
       },
     ],
   },

--- a/server/backlink-reindex.test.ts
+++ b/server/backlink-reindex.test.ts
@@ -1,0 +1,97 @@
+/**
+ * P2-2 (PRD-005 FR-4, gap F34): backlink re-indexing on source content edits.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { MemoryStorage } from "./test/memory-storage";
+import { createTestUser } from "./test/setup";
+import { reindexBacklinksForSource } from "./backlink-reindex";
+
+describe("reindexBacklinksForSource", () => {
+  let storage: MemoryStorage;
+  let teamId: string;
+  let sessionId: string;
+  let entityId: string;
+
+  beforeEach(async () => {
+    storage = new MemoryStorage();
+    const user = createTestUser({ id: "user-1" });
+    storage.setUser(user);
+    const team = await storage.createTeam({
+      name: "T",
+      teamType: "dnd",
+      diceMode: "polyhedral",
+      ownerId: user.id,
+    });
+    teamId = team.id;
+    const session = await storage.createNote({
+      teamId,
+      authorId: user.id,
+      title: "Session 1",
+      noteType: "session_log",
+      content: "We met Kettle at the tavern and talked all night.",
+    });
+    sessionId = session.id;
+    const entity = await storage.createNote({
+      teamId,
+      authorId: user.id,
+      title: "Kettle",
+      noteType: "npc",
+    });
+    entityId = entity.id;
+  });
+
+  async function addBacklink(snippet: string, start: number, end: number) {
+    return storage.createBacklink({
+      sourceNoteId: sessionId,
+      targetNoteId: entityId,
+      sourceBlockId: "block-1",
+      textSnippet: snippet,
+      startOffset: start,
+      endOffset: end,
+      createdByUserId: "user-1",
+      evidenceType: "Mention",
+      confidence: 0.8,
+    });
+  }
+
+  it("refreshes offsets when the snippet still exists at a new position", async () => {
+    const backlink = await addBacklink("met Kettle at the tavern", 3, 27);
+
+    const newContent = "Early on, we met Kettle at the tavern.";
+    const result = await reindexBacklinksForSource(storage, sessionId, newContent);
+
+    expect(result).toEqual({ refreshed: 1, rebuilt: 0, removed: 0 });
+    const updated = (await storage.getOutgoingLinks(sessionId)).find((b) => b.id === backlink.id);
+    expect(updated!.startOffset).toBe(newContent.indexOf("met Kettle at the tavern"));
+  });
+
+  it("rebuilds the snippet from the target title when the old snippet is gone", async () => {
+    await addBacklink("met Kettle at the tavern", 3, 27);
+
+    const newContent = "The party greeted Kettle warmly before departing.";
+    const result = await reindexBacklinksForSource(storage, sessionId, newContent);
+
+    expect(result).toEqual({ refreshed: 0, rebuilt: 1, removed: 0 });
+    const updated = (await storage.getOutgoingLinks(sessionId))[0];
+    expect(updated.textSnippet).toContain("Kettle");
+    expect(updated.startOffset).toBe(newContent.toLowerCase().indexOf("kettle"));
+  });
+
+  it("removes the backlink when the mention no longer exists", async () => {
+    await addBacklink("met Kettle at the tavern", 3, 27);
+
+    const result = await reindexBacklinksForSource(
+      storage,
+      sessionId,
+      "Nothing relevant happened today."
+    );
+
+    expect(result).toEqual({ refreshed: 0, rebuilt: 0, removed: 1 });
+    expect(await storage.getOutgoingLinks(sessionId)).toHaveLength(0);
+  });
+
+  it("is a no-op for notes without outgoing backlinks", async () => {
+    const result = await reindexBacklinksForSource(storage, entityId, "whatever");
+    expect(result).toEqual({ refreshed: 0, rebuilt: 0, removed: 0 });
+  });
+});

--- a/server/backlink-reindex.ts
+++ b/server/backlink-reindex.ts
@@ -1,0 +1,82 @@
+/**
+ * P2-2 (PRD-005 FR-4, gap F34): keep backlink evidence in sync with edits.
+ *
+ * The product uses an offset-based traceability model (see PRD-005's
+ * implementation notes): backlinks store a snippet plus start/end offsets into
+ * the source note's plain-text content. When that content is edited, each
+ * outgoing backlink is re-anchored:
+ *  1. If the stored snippet still occurs in the new content, offsets are
+ *     refreshed to its new position.
+ *  2. Otherwise, if the target note's title still occurs, the snippet is
+ *     rebuilt from a window around the first occurrence.
+ *  3. Otherwise the mention is gone from the note, so the backlink is removed
+ *     ("backlinks always reflect current state — no stale references").
+ */
+import type { IStorage } from "./storage";
+
+const SNIPPET_WINDOW = 100;
+const SNIPPET_MAX = 240;
+
+function windowAround(content: string, index: number, matchLength: number): string {
+  const start = Math.max(0, index - SNIPPET_WINDOW);
+  const end = Math.min(content.length, index + matchLength + SNIPPET_WINDOW);
+  const slice = content.slice(start, end).replace(/\s+/g, " ").trim();
+  return slice.length > SNIPPET_MAX ? `${slice.slice(0, SNIPPET_MAX - 3)}...` : slice;
+}
+
+export interface ReindexResult {
+  refreshed: number;
+  rebuilt: number;
+  removed: number;
+}
+
+export async function reindexBacklinksForSource(
+  storage: IStorage,
+  sourceNoteId: string,
+  newContent: string,
+): Promise<ReindexResult> {
+  const result: ReindexResult = { refreshed: 0, rebuilt: 0, removed: 0 };
+  const outgoing = await storage.getOutgoingLinks(sourceNoteId);
+  if (outgoing.length === 0) return result;
+
+  const lowerContent = newContent.toLowerCase();
+
+  for (const backlink of outgoing) {
+    const snippet = (backlink.textSnippet || "").trim();
+
+    // 1. Exact snippet still present: refresh offsets.
+    if (snippet) {
+      const idx = newContent.indexOf(snippet);
+      if (idx !== -1) {
+        await storage.updateBacklink(backlink.id, {
+          startOffset: idx,
+          endOffset: idx + snippet.length,
+        });
+        result.refreshed++;
+        continue;
+      }
+    }
+
+    // 2. Target title still mentioned: rebuild the snippet around it.
+    const target = await storage.getNote(backlink.targetNoteId);
+    const title = target?.title?.trim();
+    if (title) {
+      const titleIdx = lowerContent.indexOf(title.toLowerCase());
+      if (titleIdx !== -1) {
+        await storage.updateBacklink(backlink.id, {
+          textSnippet: windowAround(newContent, titleIdx, title.length),
+          startOffset: titleIdx,
+          endOffset: titleIdx + title.length,
+        });
+        result.rebuilt++;
+        continue;
+      }
+    }
+
+    // 3. Mention no longer exists in the note: remove the stale backlink.
+    await storage.deleteBacklink(backlink.id);
+    result.removed++;
+  }
+
+  return result;
+}

--- a/server/cleanup-suggestions.api.test.ts
+++ b/server/cleanup-suggestions.api.test.ts
@@ -215,4 +215,252 @@ describe("Cleanup Suggestions + Relationship APIs (PRD-047..049)", () => {
     expect(Array.isArray(detailRes.body.referencesOut)).toBe(true);
     expect(Array.isArray(detailRes.body.relationships)).toBe(true);
   });
+
+  // PRD-047 FR-4: only creator or DM can delete a backlink
+  it("enforces backlink delete authorization (creator or DM only)", async () => {
+    const creator = createTestUser({ id: "user-creator" });
+    const otherMember = createTestUser({ id: "user-other" });
+    storage.setUser(creator);
+    storage.setUser(otherMember);
+    await storage.createTeamMember({ teamId, userId: creator.id, role: "member" });
+    await storage.createTeamMember({ teamId, userId: otherMember.id, role: "member" });
+
+    const sessionRes = await request(app)
+      .post(`/api/teams/${teamId}/notes`)
+      .send({ title: "Session A", noteType: "session_log", content: "Met Kettle." })
+      .expect(200);
+    const entityRes = await request(app)
+      .post(`/api/teams/${teamId}/notes`)
+      .send({ title: "Kettle", noteType: "npc" })
+      .expect(200);
+
+    const creatorApp = await createTestApp({ storage, authenticatedUser: creator });
+    const backlinkRes = await request(creatorApp.app)
+      .post(`/api/teams/${teamId}/notes/${entityRes.body.id}/backlinks`)
+      .send({ sourceNoteId: sessionRes.body.id, textSnippet: "Met Kettle." })
+      .expect(200);
+
+    // Another (non-creator, non-DM) member cannot delete
+    const otherApp = await createTestApp({ storage, authenticatedUser: otherMember });
+    await request(otherApp.app)
+      .delete(`/api/teams/${teamId}/backlinks/${backlinkRes.body.id}`)
+      .expect(403);
+    otherApp.server.close();
+
+    // The creator can delete (undo)
+    await request(creatorApp.app)
+      .delete(`/api/teams/${teamId}/backlinks/${backlinkRes.body.id}`)
+      .expect(200);
+    creatorApp.server.close();
+
+    // DM can delete a backlink created by someone else
+    const secondBacklink = await storage.createBacklink({
+      sourceNoteId: sessionRes.body.id,
+      targetNoteId: entityRes.body.id,
+      sourceBlockId: "block-x",
+      textSnippet: "Met Kettle again.",
+      createdByUserId: creator.id,
+      evidenceType: "Mention",
+      confidence: 0.8,
+    });
+    await request(app)
+      .delete(`/api/teams/${teamId}/backlinks/${secondBacklink.id}`)
+      .expect(200);
+
+    const remaining = await storage.getBacklinks(entityRes.body.id);
+    expect(remaining).toHaveLength(0);
+  });
+
+  // PRD-048 FR-3 / PRD-049: only creator or DM can delete a relationship
+  it("enforces relationship delete authorization (creator or DM only)", async () => {
+    const creator = createTestUser({ id: "rel-creator" });
+    const otherMember = createTestUser({ id: "rel-other" });
+    storage.setUser(creator);
+    storage.setUser(otherMember);
+    await storage.createTeamMember({ teamId, userId: creator.id, role: "member" });
+    await storage.createTeamMember({ teamId, userId: otherMember.id, role: "member" });
+
+    const sessionRes = await request(app)
+      .post(`/api/teams/${teamId}/notes`)
+      .send({ title: "Session B", noteType: "session_log", content: "Quest talk." })
+      .expect(200);
+    const questRes = await request(app)
+      .post(`/api/teams/${teamId}/notes`)
+      .send({ title: "Save the Town", noteType: "quest" })
+      .expect(200);
+    const npcRes = await request(app)
+      .post(`/api/teams/${teamId}/notes`)
+      .send({ title: "Mayor Tobin", noteType: "npc" })
+      .expect(200);
+
+    const creatorApp = await createTestApp({ storage, authenticatedUser: creator });
+    const relationshipRes = await request(creatorApp.app)
+      .post(`/api/teams/${teamId}/relationships`)
+      .send({
+        fromNoteId: questRes.body.id,
+        toNoteId: npcRes.body.id,
+        relationshipType: "QuestHasNPC",
+        evidenceType: "Heuristic",
+        confidence: 0.72,
+        sourceNoteId: sessionRes.body.id,
+        snippetText: "Mayor Tobin asked us to save the town",
+      })
+      .expect(200);
+    creatorApp.server.close();
+
+    // Another member cannot delete
+    const otherApp = await createTestApp({ storage, authenticatedUser: otherMember });
+    await request(otherApp.app)
+      .delete(`/api/teams/${teamId}/relationships/${relationshipRes.body.id}`)
+      .expect(403);
+    otherApp.server.close();
+
+    // DM can delete
+    await request(app)
+      .delete(`/api/teams/${teamId}/relationships/${relationshipRes.body.id}`)
+      .expect(200);
+  });
+
+  // PRD-049 FR-3: quest promotion end-to-end
+  it("supports the quest promotion flow: suggestion -> quest note -> backlink + relationships visible on quest detail", async () => {
+    const npcRes = await request(app)
+      .post(`/api/teams/${teamId}/notes`)
+      .send({ title: "Lord Blackwood", noteType: "npc" })
+      .expect(200);
+    const areaRes = await request(app)
+      .post(`/api/teams/${teamId}/notes`)
+      .send({ title: "Silverwood Forest", noteType: "area" })
+      .expect(200);
+
+    const sessionRes = await request(app)
+      .post(`/api/teams/${teamId}/notes`)
+      .send({
+        title: "Session C",
+        noteType: "session_log",
+        content:
+          "We met Lord Blackwood in Silverwood Forest. He asked us to Find the Lost Relic before nightfall.",
+      })
+      .expect(200);
+
+    // 1. Cleanup suggestions include a quest promotion with suggested NPC/Area
+    const suggestionsRes = await request(app)
+      .get(`/api/teams/${teamId}/session-logs/${sessionRes.body.id}/cleanup-suggestions?mode=baseline&includeLow=1`)
+      .expect(200);
+
+    expect(suggestionsRes.body.questSuggestions.length).toBeGreaterThan(0);
+    const questSuggestion = suggestionsRes.body.questSuggestions[0];
+    expect(questSuggestion.proposedQuestTitle).toMatch(/^Find Lost Relic/);
+    expect(questSuggestion.suggestedNpcNoteId).toBe(npcRes.body.id);
+    expect(questSuggestion.suggestedAreaNoteId).toBe(areaRes.body.id);
+
+    // 2. Promote: create the quest note (seeded content), backlink, relationships
+    const questRes = await request(app)
+      .post(`/api/teams/${teamId}/notes`)
+      .send({
+        title: questSuggestion.proposedQuestTitle,
+        noteType: "quest",
+        content: `## First seen\n- Session 2026-02-17: "${questSuggestion.snippetText}"`,
+      })
+      .expect(200);
+
+    await request(app)
+      .post(`/api/teams/${teamId}/notes/${questRes.body.id}/backlinks`)
+      .send({
+        sourceNoteId: sessionRes.body.id,
+        textSnippet: questSuggestion.snippetText,
+        evidenceType: "Mention",
+        confidence: 0.8,
+      })
+      .expect(200);
+
+    await request(app)
+      .post(`/api/teams/${teamId}/relationships`)
+      .send({
+        fromNoteId: questRes.body.id,
+        toNoteId: questSuggestion.suggestedNpcNoteId,
+        relationshipType: "QuestHasNPC",
+        evidenceType: "Heuristic",
+        confidence: 0.72,
+        sourceNoteId: sessionRes.body.id,
+        snippetText: questSuggestion.snippetText,
+      })
+      .expect(200);
+
+    await request(app)
+      .post(`/api/teams/${teamId}/relationships`)
+      .send({
+        fromNoteId: questRes.body.id,
+        toNoteId: questSuggestion.suggestedAreaNoteId,
+        relationshipType: "QuestAtPlace",
+        evidenceType: "Heuristic",
+        confidence: 0.72,
+        sourceNoteId: sessionRes.body.id,
+        snippetText: questSuggestion.snippetText,
+      })
+      .expect(200);
+
+    // 3. Quest detail page shows seeded content, session reference, relationships
+    const detailRes = await request(app)
+      .get(`/api/teams/${teamId}/notes/${questRes.body.id}`)
+      .expect(200);
+
+    expect(detailRes.body.content).toContain("## First seen");
+    expect(detailRes.body.referencesIn).toHaveLength(1);
+    expect(detailRes.body.referencesIn[0].sourceNoteId).toBe(sessionRes.body.id);
+    expect(detailRes.body.referencesIn[0].sourceNoteTitle).toBe("Session C");
+
+    const relationshipTypes = detailRes.body.relationships.map(
+      (r: { relationshipType: string }) => r.relationshipType
+    );
+    expect(relationshipTypes).toContain("QuestHasNPC");
+    expect(relationshipTypes).toContain("QuestAtPlace");
+  });
+
+  // PRD-048 FR-1b/FR-2: detail references include session date + author, sorted by recency
+  it("returns session references ordered by session date with author names", async () => {
+    const entityRes = await request(app)
+      .post(`/api/teams/${teamId}/notes`)
+      .send({ title: "Kettle", noteType: "npc" })
+      .expect(200);
+
+    const olderSession = await request(app)
+      .post(`/api/teams/${teamId}/notes`)
+      .send({
+        title: "Old Session",
+        noteType: "session_log",
+        content: "Kettle waved.",
+        sessionDate: "2026-01-05T00:00:00.000Z",
+      })
+      .expect(200);
+    const newerSession = await request(app)
+      .post(`/api/teams/${teamId}/notes`)
+      .send({
+        title: "New Session",
+        noteType: "session_log",
+        content: "Kettle nodded.",
+        sessionDate: "2026-06-20T00:00:00.000Z",
+      })
+      .expect(200);
+
+    await request(app)
+      .post(`/api/teams/${teamId}/notes/${entityRes.body.id}/backlinks`)
+      .send({ sourceNoteId: olderSession.body.id, textSnippet: "Kettle waved." })
+      .expect(200);
+    await request(app)
+      .post(`/api/teams/${teamId}/notes/${entityRes.body.id}/backlinks`)
+      .send({ sourceNoteId: newerSession.body.id, textSnippet: "Kettle nodded." })
+      .expect(200);
+
+    const detailRes = await request(app)
+      .get(`/api/teams/${teamId}/notes/${entityRes.body.id}`)
+      .expect(200);
+
+    expect(detailRes.body.referencesIn).toHaveLength(2);
+    // Most recent session first
+    expect(detailRes.body.referencesIn[0].sourceNoteTitle).toBe("New Session");
+    expect(detailRes.body.referencesIn[1].sourceNoteTitle).toBe("Old Session");
+    expect(detailRes.body.referencesIn[0].sourceNoteSessionDate).toBeTruthy();
+    // Author name resolved from team membership
+    expect(typeof detailRes.body.referencesIn[0].createdByName).toBe("string");
+  });
 });

--- a/server/import-run-helpers.ts
+++ b/server/import-run-helpers.ts
@@ -1,0 +1,104 @@
+/**
+ * P2-4 "Import-run truthfulness" helpers (NOTE_TAKING_GAP_REPORT F50/F51).
+ *
+ * Pure/lightweight helpers extracted from the Nuclino commit endpoint so the
+ * stats and status lifecycle logic can be unit-tested without registering the
+ * heavy import endpoints in the test harness.
+ */
+import type { ImportRun, InsertImportRun, ImportRunStats } from "@shared/schema";
+
+/** Minimal structural slice of IStorage needed to finalize an import run. */
+export interface ImportRunStatusStore {
+  updateImportRun(id: string, data: Partial<InsertImportRun>): Promise<ImportRun>;
+}
+
+/** Page shape needed for empty-page selection math. */
+export interface SelectablePage {
+  sourcePageId: string;
+  isEmpty: boolean;
+}
+
+export interface EmptyPageSelectionOptions {
+  excludedEmptyPageIds?: unknown;
+  importEmptyPages?: boolean;
+}
+
+export interface EmptyPageSelection {
+  excludedEmptyPageIds: Set<string>;
+  /**
+   * F50: true only when zero empty pages were actually excluded. Ids in the
+   * exclusion list that do not match an empty page in the plan do not count.
+   */
+  importEmptyPages: boolean;
+}
+
+/**
+ * PRD-042 / F50: Resolve which empty pages are excluded from an import.
+ * Supports the granular `excludedEmptyPageIds` format with backward
+ * compatibility for the legacy `importEmptyPages` boolean.
+ */
+export function resolveEmptyPageSelection(
+  pages: SelectablePage[],
+  options?: EmptyPageSelectionOptions,
+): EmptyPageSelection {
+  let excludedEmptyPageIds: Set<string>;
+
+  if (options?.excludedEmptyPageIds && Array.isArray(options.excludedEmptyPageIds)) {
+    // New format: explicit list of empty page IDs to exclude
+    excludedEmptyPageIds = new Set(options.excludedEmptyPageIds as string[]);
+  } else {
+    // Legacy format: boolean importEmptyPages (defaults to true)
+    const legacyImportEmptyPages = options?.importEmptyPages !== false;
+    excludedEmptyPageIds = legacyImportEmptyPages
+      ? new Set()
+      : new Set(pages.filter(p => p.isEmpty).map(p => p.sourcePageId));
+  }
+
+  // F50: derive importEmptyPages from pages that are ACTUALLY excluded, not
+  // from the raw size of the exclusion list.
+  const excludedEmptyCount = pages.filter(
+    p => p.isEmpty && excludedEmptyPageIds.has(p.sourcePageId),
+  ).length;
+
+  return {
+    excludedEmptyPageIds,
+    importEmptyPages: excludedEmptyCount === 0,
+  };
+}
+
+/** PRD-042: Filter the plan's pages down to those that will be imported. */
+export function filterPagesToImport<T extends SelectablePage>(
+  pages: T[],
+  excludedEmptyPageIds: Set<string>,
+): T[] {
+  return pages.filter(p => !p.isEmpty || !excludedEmptyPageIds.has(p.sourcePageId));
+}
+
+/**
+ * F51: Mark an import run as truthfully completed, persisting final stats.
+ * Call this only after all note-writing work has finished.
+ */
+export async function completeImportRun(
+  storage: ImportRunStatusStore,
+  importRunId: string,
+  stats: ImportRunStats,
+): Promise<ImportRun> {
+  return storage.updateImportRun(importRunId, { stats, status: "completed" });
+}
+
+/**
+ * F51: Mark an import run as failed, keeping whatever stats were gathered
+ * before the crash. Never throws — the caller is already on an error path
+ * and still needs to send its 500 response.
+ */
+export async function markImportRunFailed(
+  storage: ImportRunStatusStore,
+  importRunId: string,
+  stats: ImportRunStats,
+): Promise<void> {
+  try {
+    await storage.updateImportRun(importRunId, { stats, status: "failed" });
+  } catch (err) {
+    console.error(`Failed to mark import run ${importRunId} as failed:`, err);
+  }
+}

--- a/server/import-runs.api.test.ts
+++ b/server/import-runs.api.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { MemoryStorage } from "./test/memory-storage";
-import type { User, Team, TeamMember, Note } from "@shared/schema";
+import type { User, Team, TeamMember, Note, ImportRunStats } from "@shared/schema";
+import {
+  resolveEmptyPageSelection,
+  filterPagesToImport,
+  completeImportRun,
+  markImportRunFailed,
+} from "./import-run-helpers";
 
 describe("Import Runs API (PRD-015A)", () => {
   let storage: MemoryStorage;
@@ -763,6 +769,141 @@ describe("Import Runs API (PRD-015A)", () => {
         expect(result.map(p => p.sourcePageId)).toEqual([
           "page-1", "page-2", "empty-2", "empty-3"
         ]);
+      });
+    });
+  });
+
+  describe("Import-run truthfulness (P2-4)", () => {
+    const partialStats: ImportRunStats = {
+      totalPagesDetected: 10,
+      notesCreated: 4,
+      notesUpdated: 1,
+      notesSkipped: 0,
+      emptyPagesImported: 1,
+      linksResolved: 0,
+      warningsCount: 2,
+    };
+
+    describe("F51: run status lifecycle", () => {
+      it("supports the pending -> completed lifecycle", async () => {
+        // Run is created "pending" before any note is written
+        const run = await storage.createImportRun({
+          teamId: testTeam.id,
+          sourceSystem: "NUCLINO",
+          createdByUserId: testUser.id,
+          status: "pending",
+          options: { importEmptyPages: true, defaultVisibility: "private" },
+          stats: null,
+        });
+        expect(run.status).toBe("pending");
+        expect(run.stats).toBeNull();
+
+        // ...note-writing work happens...
+
+        const completed = await completeImportRun(storage, run.id, partialStats);
+        expect(completed.status).toBe("completed");
+        expect(completed.stats).toEqual(partialStats);
+
+        const fetched = await storage.getImportRun(run.id);
+        expect(fetched?.status).toBe("completed");
+      });
+
+      it("marks the run failed with partial stats when note writing throws", async () => {
+        const run = await storage.createImportRun({
+          teamId: testTeam.id,
+          sourceSystem: "NUCLINO",
+          createdByUserId: testUser.id,
+          status: "pending",
+          options: { importEmptyPages: true, defaultVisibility: "private" },
+          stats: null,
+        });
+
+        // Simulate the commit endpoint's error path: note-writing work throws
+        // mid-run after some stats have been gathered.
+        let notesCreated = 0;
+        const doImportWork = async () => {
+          notesCreated++;
+          throw new Error("database exploded mid-import");
+        };
+
+        await expect(doImportWork()).rejects.toThrow("database exploded mid-import");
+        await markImportRunFailed(storage, run.id, {
+          ...partialStats,
+          notesCreated,
+        });
+
+        const fetched = await storage.getImportRun(run.id);
+        expect(fetched?.status).toBe("failed");
+        // Partial stats gathered before the crash are preserved
+        expect(fetched?.stats?.notesCreated).toBe(1);
+        expect(fetched?.stats?.totalPagesDetected).toBe(10);
+      });
+
+      it("markImportRunFailed never throws, even when the storage update fails", async () => {
+        // Unknown run id -> MemoryStorage.updateImportRun throws internally
+        await expect(
+          markImportRunFailed(storage, "nonexistent-run-id", partialStats)
+        ).resolves.toBeUndefined();
+      });
+    });
+
+    describe("F50: empty-page stats for partial selection", () => {
+      const pages = [
+        { sourcePageId: "page-1", isEmpty: false },
+        { sourcePageId: "page-2", isEmpty: false },
+        { sourcePageId: "empty-1", isEmpty: true },
+        { sourcePageId: "empty-2", isEmpty: true },
+        { sourcePageId: "empty-3", isEmpty: true },
+      ];
+
+      it("records importEmptyPages=false and the true imported-empty count for partial selection", () => {
+        const { excludedEmptyPageIds, importEmptyPages } = resolveEmptyPageSelection(pages, {
+          excludedEmptyPageIds: ["empty-2"],
+        });
+
+        // One empty page was excluded, so options must not claim all were imported
+        expect(importEmptyPages).toBe(false);
+
+        // The pages that actually get imported include 2 of the 3 empty pages
+        const pagesToImport = filterPagesToImport(pages, excludedEmptyPageIds);
+        const emptyPagesImported = pagesToImport.filter(p => p.isEmpty).length;
+        expect(emptyPagesImported).toBe(2);
+        expect(pagesToImport.map(p => p.sourcePageId)).toEqual([
+          "page-1", "page-2", "empty-1", "empty-3",
+        ]);
+      });
+
+      it("records importEmptyPages=true when the exclusion list is empty", () => {
+        const { excludedEmptyPageIds, importEmptyPages } = resolveEmptyPageSelection(pages, {
+          excludedEmptyPageIds: [],
+        });
+        expect(importEmptyPages).toBe(true);
+        const pagesToImport = filterPagesToImport(pages, excludedEmptyPageIds);
+        expect(pagesToImport.filter(p => p.isEmpty).length).toBe(3);
+      });
+
+      it("ignores excluded ids that do not match an actual empty page", () => {
+        const { importEmptyPages } = resolveEmptyPageSelection(pages, {
+          excludedEmptyPageIds: ["nonexistent-id", "page-1"],
+        });
+        // No real empty page was excluded, so importEmptyPages stays true
+        expect(importEmptyPages).toBe(true);
+      });
+
+      it("supports the legacy importEmptyPages=false boolean (all empties excluded)", () => {
+        const { excludedEmptyPageIds, importEmptyPages } = resolveEmptyPageSelection(pages, {
+          importEmptyPages: false,
+        });
+        expect(importEmptyPages).toBe(false);
+        const pagesToImport = filterPagesToImport(pages, excludedEmptyPageIds);
+        expect(pagesToImport.filter(p => p.isEmpty).length).toBe(0);
+        expect(pagesToImport.length).toBe(2);
+      });
+
+      it("defaults to importing all empty pages when options are omitted", () => {
+        const { excludedEmptyPageIds, importEmptyPages } = resolveEmptyPageSelection(pages);
+        expect(importEmptyPages).toBe(true);
+        expect(filterPagesToImport(pages, excludedEmptyPageIds).length).toBe(5);
       });
     });
   });

--- a/server/jobs/enrichment-worker.ts
+++ b/server/jobs/enrichment-worker.ts
@@ -300,13 +300,13 @@ async function extractRelationshipsWithCache(
   provider: AIProvider,
   cache: AICache,
   teamId: string
-): Promise<import("./ai").RelationshipResult[]> {
+): Promise<import("../ai").RelationshipResult[]> {
   if (notes.length < 2) {
     return [];
   }
 
   // Phase 1: Check cache for all note pairs
-  const cachedRelationships: import("./ai").RelationshipResult[] = [];
+  const cachedRelationships: import("../ai").RelationshipResult[] = [];
   const checkedPairs = new Set<string>();
   const uncachedPairs: Array<{ noteA: typeof notes[0]; noteB: typeof notes[0]; pairKey: string }> = [];
   let cacheHitCount = 0;
@@ -348,7 +348,7 @@ async function extractRelationshipsWithCache(
   }
 
   // Phase 2: Extract relationships for uncached pairs
-  let freshResults: import("./ai").RelationshipResult[] = [];
+  let freshResults: import("../ai").RelationshipResult[] = [];
 
   if (uncachedPairs.length > 0) {
     // Get unique notes that need relationship analysis
@@ -385,7 +385,7 @@ async function extractRelationshipsWithCache(
     for (const { noteA, noteB, pairKey } of uncachedPairs) {
       if (!pairsWithRelationships.has(pairKey)) {
         // This pair was analyzed but no relationship was found - cache that fact
-        const noRelationshipResult: import("./ai").RelationshipResult = {
+        const noRelationshipResult: import("../ai").RelationshipResult = {
           fromNoteId: noteA.id,
           toNoteId: noteB.id,
           relationshipType: "None",
@@ -409,7 +409,7 @@ async function extractRelationshipsWithCache(
   // Merge cached and fresh results, deduplicating by pair (exclude "None" relationships)
   const allResults = [...cachedRelationships, ...freshResults];
   const seenPairs = new Set<string>();
-  const deduplicatedResults: import("./ai").RelationshipResult[] = [];
+  const deduplicatedResults: import("../ai").RelationshipResult[] = [];
 
   for (const result of allResults) {
     if (result.relationshipType === "None") continue; // Don't include "no relationship" in results

--- a/server/note-visibility.test.ts
+++ b/server/note-visibility.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { canViewNote, filterVisibleNotes } from "./note-visibility";
+
+describe("note-visibility (P0-1 shared privacy predicate)", () => {
+  const author = "author-1";
+  const otherMember = "member-2";
+  const dm = "dm-user";
+
+  const publicNote = { id: "n1", isPrivate: false, authorId: author };
+  const privateNote = { id: "n2", isPrivate: true, authorId: author };
+  const nullPrivacyNote = { id: "n3", isPrivate: null, authorId: author };
+
+  describe("canViewNote", () => {
+    it("allows anyone to view a non-private note", () => {
+      expect(canViewNote(publicNote, otherMember, "member")).toBe(true);
+      expect(canViewNote(publicNote, author, "member")).toBe(true);
+    });
+
+    it("treats isPrivate: null as non-private", () => {
+      expect(canViewNote(nullPrivacyNote, otherMember, "member")).toBe(true);
+    });
+
+    it("allows the author to view their own private note", () => {
+      expect(canViewNote(privateNote, author, "member")).toBe(true);
+    });
+
+    it("denies another member viewing someone else's private note", () => {
+      expect(canViewNote(privateNote, otherMember, "member")).toBe(false);
+    });
+
+    it("allows the DM to view any private note (DM sees all)", () => {
+      expect(canViewNote(privateNote, dm, "dm")).toBe(true);
+    });
+
+    it("allows the DM to view their own and public notes too", () => {
+      expect(canViewNote(publicNote, dm, "dm")).toBe(true);
+      expect(canViewNote({ isPrivate: true, authorId: dm }, dm, "dm")).toBe(true);
+    });
+  });
+
+  describe("filterVisibleNotes", () => {
+    const notes = [publicNote, privateNote, nullPrivacyNote];
+
+    it("keeps only public + own private notes for a member", () => {
+      const memberPrivate = { id: "n4", isPrivate: true, authorId: otherMember };
+      const visible = filterVisibleNotes([...notes, memberPrivate], otherMember, "member");
+      expect(visible.map((n) => n.id)).toEqual(["n1", "n3", "n4"]);
+    });
+
+    it("keeps everything for the author", () => {
+      const visible = filterVisibleNotes(notes, author, "member");
+      expect(visible.map((n) => n.id)).toEqual(["n1", "n2", "n3"]);
+    });
+
+    it("keeps everything for the DM", () => {
+      const visible = filterVisibleNotes(notes, dm, "dm");
+      expect(visible.map((n) => n.id)).toEqual(["n1", "n2", "n3"]);
+    });
+
+    it("returns an empty array for empty input", () => {
+      expect(filterVisibleNotes([], otherMember, "member")).toEqual([]);
+    });
+
+    it("preserves extra fields on filtered notes", () => {
+      const rich = [{ id: "n5", isPrivate: false, authorId: author, title: "T" }];
+      const visible = filterVisibleNotes(rich, otherMember, "member");
+      expect(visible[0].title).toBe("T");
+    });
+  });
+});

--- a/server/note-visibility.ts
+++ b/server/note-visibility.ts
@@ -1,0 +1,32 @@
+// P0-1 (NOTE_TAKING_GAP_REPORT F0/F48/F81/F9): shared note-privacy predicate.
+// Single source of truth imported by BOTH server/routes.ts (production) and
+// server/test/test-routes.ts (test harness) so the two can never diverge on
+// privacy semantics again (the PRD-021 lesson).
+
+export interface NoteVisibilityFields {
+  isPrivate: boolean | null;
+  authorId: string;
+}
+
+/**
+ * A note is viewable when it is not private, or the caller authored it,
+ * or the caller is the team DM (DM sees all).
+ */
+export function canViewNote(
+  note: NoteVisibilityFields,
+  userId: string,
+  role: "dm" | "member",
+): boolean {
+  return !note.isPrivate || note.authorId === userId || role === "dm";
+}
+
+/**
+ * Filters a list of notes down to those the caller may view.
+ */
+export function filterVisibleNotes<T extends NoteVisibilityFields>(
+  notes: T[],
+  userId: string,
+  role: "dm" | "member",
+): T[] {
+  return notes.filter((note) => canViewNote(note, userId, role));
+}

--- a/server/notes-handlers.ts
+++ b/server/notes-handlers.ts
@@ -1,0 +1,232 @@
+/**
+ * Shared notes API handlers (gap P2-3).
+ *
+ * The privacy leak (F0), the sessionDate coercion bug (PRD-021), and the
+ * idempotency divergence (PRD-023) all happened because server/routes.ts and
+ * server/test/test-routes.ts re-implemented the same handlers separately.
+ * These factories are the single implementation registered by BOTH routers,
+ * making that divergence class structurally impossible for the notes surface.
+ */
+import type { Request, Response } from "express";
+import type { IStorage } from "./storage";
+import type { QuestStatus } from "@shared/schema";
+import { canViewNote, filterVisibleNotes } from "./note-visibility";
+import { reindexBacklinksForSource } from "./backlink-reindex";
+
+type AnyRequest = Request & { user: { claims: { sub: string } } };
+
+function getUserId(req: Request): string {
+  return (req as AnyRequest).user.claims.sub;
+}
+
+export function makeListNotesHandler(storage: IStorage) {
+  return async (req: Request, res: Response) => {
+    try {
+      const userId = getUserId(req);
+      const { teamId } = req.params;
+
+      const member = await storage.getTeamMember(teamId, userId);
+      if (!member) {
+        return res.status(403).json({ message: "Not a team member" });
+      }
+
+      const notes = await storage.getNotes(teamId);
+      // P0-1 (F0/F48): never ship other authors' private notes to members
+      res.json(filterVisibleNotes(notes, userId, member.role));
+    } catch (error) {
+      console.error("Error fetching notes:", error);
+      res.status(500).json({ message: "Failed to fetch notes" });
+    }
+  };
+}
+
+export function makeTodaySessionHandler(storage: IStorage) {
+  return async (req: Request, res: Response) => {
+    try {
+      const userId = getUserId(req);
+      const { teamId } = req.params;
+
+      const member = await storage.getTeamMember(teamId, userId);
+      if (!member) {
+        return res.status(403).json({ message: "Not a team member" });
+      }
+
+      const todaySession = await storage.findSessionByDate(teamId, new Date());
+      // Privacy: today's session may be another author's private note
+      if (todaySession && !canViewNote(todaySession, userId, member.role)) {
+        return res.json(null);
+      }
+      res.json(todaySession ?? null);
+    } catch (error) {
+      console.error("Error fetching today's session:", error);
+      res.status(500).json({ message: "Failed to fetch today's session" });
+    }
+  };
+}
+
+export function makeNeedsReviewHandler(storage: IStorage) {
+  return async (req: Request, res: Response) => {
+    try {
+      const userId = getUserId(req);
+      const { teamId } = req.params;
+
+      const member = await storage.getTeamMember(teamId, userId);
+      if (!member) {
+        return res.status(403).json({ message: "Not a team member" });
+      }
+
+      const items = await storage.getPendingLowConfidenceClassifications(teamId);
+      // P0-1 (F81): don't expose private notes' titles/explanations to non-authors
+      const teamNotes = await storage.getNotes(teamId);
+      const visibleNoteIds = new Set(
+        filterVisibleNotes(teamNotes, userId, member.role).map((note) => note.id),
+      );
+      const visibleItems = items.filter((item) => visibleNoteIds.has(item.noteId));
+      res.json({ items: visibleItems, count: visibleItems.length });
+    } catch (error) {
+      console.error("Error fetching needs-review items:", error);
+      res.status(500).json({ message: "Failed to fetch needs-review items" });
+    }
+  };
+}
+
+export function makeCreateNoteHandler(storage: IStorage) {
+  return async (req: Request, res: Response) => {
+    try {
+      const userId = getUserId(req);
+      const { teamId } = req.params;
+      // PRD-034: Accept importRunId for suggestion-created entities to enable cascade delete
+      const { title, content, noteType, isPrivate, questStatus, contentBlocks, sessionDate, linkedNoteIds, importRunId } = req.body;
+
+      const member = await storage.getTeamMember(teamId, userId);
+      if (!member) {
+        return res.status(403).json({ message: "Not a team member" });
+      }
+
+      // For session_log type, check if one already exists for the given date (idempotency)
+      if (noteType === "session_log" && sessionDate) {
+        const existing = await storage.findSessionByDate(teamId, new Date(sessionDate));
+        if (existing) {
+          // P0-1 (F9): don't leak another author's private session content
+          if (!canViewNote(existing, userId, member.role)) {
+            return res.status(409).json({ message: "A private session already exists for this date" });
+          }
+          // Return existing session instead of creating duplicate
+          return res.status(200).json(existing);
+        }
+      }
+
+      const note = await storage.createNote({
+        teamId,
+        authorId: userId,
+        title,
+        content,
+        noteType,
+        isPrivate,
+        // PRD-004 / gap F38: quests are proto-quests at capture time — default
+        // to "lead" in the shared handler, not just the test storage.
+        questStatus:
+          noteType === "quest" ? ((questStatus as QuestStatus) ?? "lead") : questStatus,
+        contentBlocks,
+        sessionDate: sessionDate ? new Date(sessionDate) : undefined,
+        linkedNoteIds,
+        importRunId: importRunId || undefined, // PRD-034: Track import origin for cascade delete
+      });
+
+      res.json(note);
+    } catch (error) {
+      console.error("Error creating note:", error);
+      res.status(500).json({ message: "Failed to create note" });
+    }
+  };
+}
+
+export function makeUpdateNoteHandler(storage: IStorage) {
+  return async (req: Request, res: Response) => {
+    try {
+      const userId = getUserId(req);
+      const { teamId, noteId } = req.params;
+
+      const member = await storage.getTeamMember(teamId, userId);
+      if (!member) {
+        return res.status(403).json({ message: "Not a team member" });
+      }
+
+      const existingNote = await storage.getNote(noteId);
+      if (!existingNote || existingNote.teamId !== teamId) {
+        return res.status(404).json({ message: "Note not found" });
+      }
+
+      if (existingNote.authorId !== userId && member.role !== "dm") {
+        return res.status(403).json({ message: "Not authorized to edit this note" });
+      }
+
+      // Explicit allow-list instead of spreading req.body — the enum/field
+      // drift bug family (PRD-029/039/045) came from implicit field handling.
+      const updateData: Record<string, unknown> = {};
+      const body = req.body ?? {};
+      for (const field of [
+        "title",
+        "content",
+        "noteType",
+        "isPrivate",
+        "questStatus",
+        "contentBlocks",
+        "linkedNoteIds",
+      ]) {
+        if (field in body) updateData[field] = body[field];
+      }
+      if ("sessionDate" in body) {
+        updateData.sessionDate = body.sessionDate ? new Date(body.sessionDate) : body.sessionDate;
+      }
+      // PRD-003 FR-5 (gap F19): mark-reviewed support
+      if ("reviewedAt" in body) {
+        updateData.reviewedAt = body.reviewedAt ? new Date(body.reviewedAt) : null;
+      }
+
+      const note = await storage.updateNote(noteId, updateData);
+
+      // P2-2 (F34, PRD-005 FR-4): content edits re-index or remove backlinks
+      // sourced from this note so evidence never goes stale.
+      if ("content" in body && typeof body.content === "string") {
+        await reindexBacklinksForSource(storage, noteId, body.content).catch((err) => {
+          console.error("Backlink re-index failed:", err);
+        });
+      }
+
+      res.json(note);
+    } catch (error) {
+      console.error("Error updating note:", error);
+      res.status(500).json({ message: "Failed to update note" });
+    }
+  };
+}
+
+export function makeDeleteNoteHandler(storage: IStorage) {
+  return async (req: Request, res: Response) => {
+    try {
+      const userId = getUserId(req);
+      const { teamId, noteId } = req.params;
+
+      const member = await storage.getTeamMember(teamId, userId);
+      if (!member) {
+        return res.status(403).json({ message: "Not a team member" });
+      }
+
+      const existingNote = await storage.getNote(noteId);
+      if (!existingNote || existingNote.teamId !== teamId) {
+        return res.status(404).json({ message: "Note not found" });
+      }
+
+      if (existingNote.authorId !== userId && member.role !== "dm") {
+        return res.status(403).json({ message: "Not authorized to delete this note" });
+      }
+
+      await storage.deleteNote(noteId);
+      res.json({ success: true });
+    } catch (error) {
+      console.error("Error deleting note:", error);
+      res.status(500).json({ message: "Failed to delete note" });
+    }
+  };
+}

--- a/server/privacy.api.test.ts
+++ b/server/privacy.api.test.ts
@@ -1,0 +1,319 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import request from "supertest";
+import type { Express } from "express";
+import type { Server } from "http";
+import { createTestApp, createTestUser, type TestUser } from "./test/setup";
+import { MemoryStorage } from "./test/memory-storage";
+import type { Team, Note, ImportRun, EnrichmentRun } from "@shared/schema";
+
+/**
+ * P0-1 (NOTE_TAKING_GAP_REPORT F0/F48/F81/F9): server-side privacy enforcement.
+ * Private notes must be invisible to non-author members (DM sees all) on:
+ * - the notes list
+ * - the needs-review list (titles + AI explanations)
+ * - the classification PATCH (approve/reject/reclassify)
+ * - the idempotent session_log POST path
+ */
+describe("Privacy enforcement (P0-1)", () => {
+  let storage: MemoryStorage;
+  let dmUser: TestUser;
+  let authorUser: TestUser;
+  let otherUser: TestUser;
+  let dmApp: Express;
+  let authorApp: Express;
+  let otherApp: Express;
+  let servers: Server[];
+  let team: Team;
+
+  beforeEach(async () => {
+    storage = new MemoryStorage();
+    servers = [];
+
+    dmUser = createTestUser({ id: "user-dm", email: "dm@test.com" });
+    authorUser = createTestUser({ id: "user-author", email: "author@test.com" });
+    otherUser = createTestUser({ id: "user-other", email: "other@test.com" });
+    storage.setUser(dmUser);
+    storage.setUser(authorUser);
+    storage.setUser(otherUser);
+
+    const dmResult = await createTestApp({ storage, authenticatedUser: dmUser });
+    dmApp = dmResult.app;
+    servers.push(dmResult.server);
+
+    const teamRes = await request(dmApp)
+      .post("/api/teams")
+      .send({ name: "Privacy Team", teamType: "dnd" })
+      .expect(200);
+    team = teamRes.body;
+
+    await storage.createTeamMember({ teamId: team.id, userId: authorUser.id, role: "member" });
+    await storage.createTeamMember({ teamId: team.id, userId: otherUser.id, role: "member" });
+
+    const authorResult = await createTestApp({ storage, authenticatedUser: authorUser });
+    authorApp = authorResult.app;
+    servers.push(authorResult.server);
+
+    const otherResult = await createTestApp({ storage, authenticatedUser: otherUser });
+    otherApp = otherResult.app;
+    servers.push(otherResult.server);
+  });
+
+  afterEach(() => {
+    for (const server of servers) server.close();
+  });
+
+  async function createPrivateNote(overrides: Record<string, unknown> = {}): Promise<Note> {
+    const res = await request(authorApp)
+      .post(`/api/teams/${team.id}/notes`)
+      .send({
+        title: "Secret Villain Plans",
+        content: "The lich is secretly the mayor",
+        noteType: "npc",
+        isPrivate: true,
+        ...overrides,
+      })
+      .expect(200);
+    return res.body;
+  }
+
+  describe("GET /api/teams/:teamId/notes", () => {
+    it("hides another author's private note from a member but shows it to the author and the DM", async () => {
+      await createPrivateNote();
+      await request(authorApp)
+        .post(`/api/teams/${team.id}/notes`)
+        .send({ title: "Public Lore", noteType: "area", isPrivate: false })
+        .expect(200);
+
+      const memberRes = await request(otherApp).get(`/api/teams/${team.id}/notes`).expect(200);
+      expect(memberRes.body.map((n: Note) => n.title)).toEqual(["Public Lore"]);
+
+      const authorRes = await request(authorApp).get(`/api/teams/${team.id}/notes`).expect(200);
+      expect(authorRes.body).toHaveLength(2);
+
+      const dmRes = await request(dmApp).get(`/api/teams/${team.id}/notes`).expect(200);
+      expect(dmRes.body).toHaveLength(2);
+    });
+  });
+
+  describe("GET /api/teams/:teamId/notes/needs-review (F81)", () => {
+    let importRun: ImportRun;
+    let enrichmentRun: EnrichmentRun;
+    let privateNote: Note;
+    let publicNote: Note;
+    let privateClassificationId: string;
+
+    beforeEach(async () => {
+      importRun = await storage.createImportRun({
+        teamId: team.id,
+        sourceSystem: "NUCLINO",
+        createdByUserId: dmUser.id,
+        status: "completed",
+        options: { importEmptyPages: true, defaultVisibility: "private" },
+        stats: {
+          totalPagesDetected: 2,
+          notesCreated: 2,
+          notesUpdated: 0,
+          notesSkipped: 0,
+          emptyPagesImported: 0,
+          linksResolved: 0,
+          warningsCount: 0,
+        },
+      });
+      enrichmentRun = await storage.createEnrichmentRun({
+        importRunId: importRun.id,
+        teamId: team.id,
+        createdByUserId: dmUser.id,
+        status: "completed",
+        totals: {
+          notesProcessed: 2,
+          classificationsCreated: 2,
+          relationshipsFound: 0,
+          highConfidenceCount: 0,
+          lowConfidenceCount: 2,
+          userReviewRequired: 2,
+        },
+      });
+
+      privateNote = await createPrivateNote();
+      const publicRes = await request(authorApp)
+        .post(`/api/teams/${team.id}/notes`)
+        .send({ title: "Public Tavern", noteType: "poi", isPrivate: false })
+        .expect(200);
+      publicNote = publicRes.body;
+
+      const privateClassification = await storage.createNoteClassification({
+        noteId: privateNote.id,
+        enrichmentRunId: enrichmentRun.id,
+        inferredType: "NPC",
+        confidence: 0.4,
+        explanation: "Mentions the lich's secret identity",
+        extractedEntities: [],
+        status: "pending",
+      });
+      privateClassificationId = privateClassification.id;
+
+      await storage.createNoteClassification({
+        noteId: publicNote.id,
+        enrichmentRunId: enrichmentRun.id,
+        inferredType: "Area",
+        confidence: 0.5,
+        explanation: "Looks like a tavern",
+        extractedEntities: [],
+        status: "pending",
+      });
+    });
+
+    it("excludes private notes' items for a non-author member", async () => {
+      const res = await request(otherApp)
+        .get(`/api/teams/${team.id}/notes/needs-review`)
+        .expect(200);
+
+      expect(res.body.count).toBe(1);
+      expect(res.body.items).toHaveLength(1);
+      expect(res.body.items[0].noteId).toBe(publicNote.id);
+      const titles = res.body.items.map((i: any) => i.noteTitle);
+      expect(titles).not.toContain("Secret Villain Plans");
+    });
+
+    it("includes the private note's item for its author", async () => {
+      const res = await request(authorApp)
+        .get(`/api/teams/${team.id}/notes/needs-review`)
+        .expect(200);
+
+      expect(res.body.count).toBe(2);
+      expect(res.body.items.map((i: any) => i.noteId)).toContain(privateNote.id);
+    });
+
+    it("includes the private note's item for the DM", async () => {
+      const res = await request(dmApp)
+        .get(`/api/teams/${team.id}/notes/needs-review`)
+        .expect(200);
+
+      expect(res.body.count).toBe(2);
+      expect(res.body.items.map((i: any) => i.noteId)).toContain(privateNote.id);
+    });
+
+    describe("PATCH /api/teams/:teamId/classifications/:classificationId (F81)", () => {
+      it("returns 404 when a non-author member tries to approve a private note's classification", async () => {
+        const res = await request(otherApp)
+          .patch(`/api/teams/${team.id}/classifications/${privateClassificationId}`)
+          .send({ status: "approved" })
+          .expect(404);
+
+        expect(res.body.message).toBe("Classification not found");
+
+        // Classification must be untouched
+        const classifications = await storage.getNoteClassificationsByEnrichmentRun(enrichmentRun.id);
+        const target = classifications.find((c) => c.id === privateClassificationId);
+        expect(target?.status).toBe("pending");
+      });
+
+      it("returns 404 when a non-author member tries to reject it too", async () => {
+        await request(otherApp)
+          .patch(`/api/teams/${team.id}/classifications/${privateClassificationId}`)
+          .send({ status: "rejected" })
+          .expect(404);
+      });
+
+      it("lets the author approve their own private note's classification", async () => {
+        const res = await request(authorApp)
+          .patch(`/api/teams/${team.id}/classifications/${privateClassificationId}`)
+          .send({ status: "approved" })
+          .expect(200);
+
+        expect(res.body.status).toBe("approved");
+        const updatedNote = await storage.getNote(privateNote.id);
+        expect(updatedNote?.noteType).toBe("npc");
+      });
+
+      it("lets the DM approve a member's private note's classification", async () => {
+        const res = await request(dmApp)
+          .patch(`/api/teams/${team.id}/classifications/${privateClassificationId}`)
+          .send({ status: "approved" })
+          .expect(200);
+
+        expect(res.body.status).toBe("approved");
+      });
+
+      it("returns 404 for a classification id that does not exist", async () => {
+        await request(otherApp)
+          .patch(`/api/teams/${team.id}/classifications/does-not-exist`)
+          .send({ status: "approved" })
+          .expect(404);
+      });
+    });
+  });
+
+  describe("POST /api/teams/:teamId/notes idempotent session path (F9)", () => {
+    const today = new Date().toISOString();
+
+    it("returns 409 without leaking content when another author's private session exists for the date", async () => {
+      const privateSession = await createPrivateNote({
+        title: "Session 12 (DM eyes only)",
+        content: "Players are about to be betrayed",
+        noteType: "session_log",
+        sessionDate: today,
+      });
+
+      const res = await request(otherApp)
+        .post(`/api/teams/${team.id}/notes`)
+        .send({ title: "Session 12", noteType: "session_log", sessionDate: today })
+        .expect(409);
+
+      expect(res.body.message).toBe("A private session already exists for this date");
+      expect(JSON.stringify(res.body)).not.toContain("betrayed");
+      expect(res.body.id).toBeUndefined();
+
+      // No duplicate session was created
+      const sessions = (await storage.getNotes(team.id)).filter((n) => n.noteType === "session_log");
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0].id).toBe(privateSession.id);
+    });
+
+    it("returns the existing private session to its own author (200)", async () => {
+      const privateSession = await createPrivateNote({
+        title: "Session 12 (DM eyes only)",
+        noteType: "session_log",
+        sessionDate: today,
+      });
+
+      const res = await request(authorApp)
+        .post(`/api/teams/${team.id}/notes`)
+        .send({ title: "Session 12", noteType: "session_log", sessionDate: today })
+        .expect(200);
+
+      expect(res.body.id).toBe(privateSession.id);
+    });
+
+    it("returns the existing private session to the DM (200, DM sees all)", async () => {
+      const privateSession = await createPrivateNote({
+        title: "Session 12 (DM eyes only)",
+        noteType: "session_log",
+        sessionDate: today,
+      });
+
+      const res = await request(dmApp)
+        .post(`/api/teams/${team.id}/notes`)
+        .send({ title: "Session 12", noteType: "session_log", sessionDate: today })
+        .expect(200);
+
+      expect(res.body.id).toBe(privateSession.id);
+    });
+
+    it("still returns an existing public session to any member (200)", async () => {
+      const publicSession = await createPrivateNote({
+        title: "Session 12",
+        noteType: "session_log",
+        isPrivate: false,
+        sessionDate: today,
+      });
+
+      const res = await request(otherApp)
+        .post(`/api/teams/${team.id}/notes`)
+        .send({ title: "Session 12", noteType: "session_log", sessionDate: today })
+        .expect(200);
+
+      expect(res.body.id).toBe(publicSession.id);
+    });
+  });
+});

--- a/server/review-mode.api.test.ts
+++ b/server/review-mode.api.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Review Mode API tests (P2-5 / gap F19+F21, PRD-003 FR-5).
+ *
+ * Covers the reviewedAt flag on session logs:
+ * - PATCH sets and clears it, and it round-trips on GET
+ * - unrelated PATCHes (title/content) leave it untouched
+ * - a non-author member cannot set it on another author's private session
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import request from "supertest";
+import type { Express } from "express";
+import type { Server } from "http";
+import { createTestApp, createTestUser } from "./test/setup";
+import { MemoryStorage } from "./test/memory-storage";
+
+describe("Review Mode API (PRD-003 FR-5)", () => {
+  let app: Express;
+  let server: Server;
+  let storage: MemoryStorage;
+  let testUser: ReturnType<typeof createTestUser>;
+  let teamId: string;
+
+  beforeEach(async () => {
+    testUser = createTestUser({ id: "user-dm" });
+    storage = new MemoryStorage();
+    storage.setUser(testUser);
+    const result = await createTestApp({ storage, authenticatedUser: testUser });
+    app = result.app;
+    server = result.server;
+
+    const teamRes = await request(app)
+      .post("/api/teams")
+      .send({
+        name: "Test Team",
+        teamType: "dnd",
+        diceMode: "polyhedral",
+      })
+      .expect(200);
+    teamId = teamRes.body.id;
+  });
+
+  afterEach(() => {
+    server.close();
+  });
+
+  it("sets and clears reviewedAt via PATCH, round-tripping on GET", async () => {
+    const sessionRes = await request(app)
+      .post(`/api/teams/${teamId}/notes`)
+      .send({
+        title: "Session 1",
+        noteType: "session_log",
+        content: "Met Lord Blackwood.",
+      })
+      .expect(200);
+    const noteId = sessionRes.body.id;
+    // Fresh session logs start unreviewed
+    expect(sessionRes.body.reviewedAt ?? null).toBeNull();
+
+    // Set the flag
+    const reviewedAt = "2026-07-06T12:00:00.000Z";
+    const patchRes = await request(app)
+      .patch(`/api/teams/${teamId}/notes/${noteId}`)
+      .send({ reviewedAt })
+      .expect(200);
+    expect(new Date(patchRes.body.reviewedAt).toISOString()).toBe(reviewedAt);
+
+    // Round-trips on GET
+    const getRes = await request(app)
+      .get(`/api/teams/${teamId}/notes/${noteId}`)
+      .expect(200);
+    expect(new Date(getRes.body.reviewedAt).toISOString()).toBe(reviewedAt);
+
+    // Clear the flag (un-mark)
+    const clearRes = await request(app)
+      .patch(`/api/teams/${teamId}/notes/${noteId}`)
+      .send({ reviewedAt: null })
+      .expect(200);
+    expect(clearRes.body.reviewedAt ?? null).toBeNull();
+
+    const getAfterClear = await request(app)
+      .get(`/api/teams/${teamId}/notes/${noteId}`)
+      .expect(200);
+    expect(getAfterClear.body.reviewedAt ?? null).toBeNull();
+  });
+
+  it("preserves reviewedAt across unrelated PATCHes (title/content)", async () => {
+    const sessionRes = await request(app)
+      .post(`/api/teams/${teamId}/notes`)
+      .send({
+        title: "Session 2",
+        noteType: "session_log",
+        content: "Original content.",
+      })
+      .expect(200);
+    const noteId = sessionRes.body.id;
+
+    const reviewedAt = "2026-07-06T09:30:00.000Z";
+    await request(app)
+      .patch(`/api/teams/${teamId}/notes/${noteId}`)
+      .send({ reviewedAt })
+      .expect(200);
+
+    // PATCH other fields without mentioning reviewedAt
+    const patchRes = await request(app)
+      .patch(`/api/teams/${teamId}/notes/${noteId}`)
+      .send({ title: "Session 2 — renamed", content: "Updated content." })
+      .expect(200);
+    expect(patchRes.body.title).toBe("Session 2 — renamed");
+    expect(patchRes.body.content).toBe("Updated content.");
+    expect(new Date(patchRes.body.reviewedAt).toISOString()).toBe(reviewedAt);
+
+    const getRes = await request(app)
+      .get(`/api/teams/${teamId}/notes/${noteId}`)
+      .expect(200);
+    expect(new Date(getRes.body.reviewedAt).toISOString()).toBe(reviewedAt);
+  });
+
+  it("rejects a non-author member setting reviewedAt on another author's private session", async () => {
+    const author = createTestUser({ id: "user-author" });
+    const otherMember = createTestUser({ id: "user-other" });
+    storage.setUser(author);
+    storage.setUser(otherMember);
+    await storage.createTeamMember({ teamId, userId: author.id, role: "member" });
+    await storage.createTeamMember({ teamId, userId: otherMember.id, role: "member" });
+
+    const privateSession = await storage.createNote({
+      teamId,
+      authorId: author.id,
+      title: "Private Session",
+      noteType: "session_log",
+      isPrivate: true,
+      content: "Secret plans.",
+    });
+
+    // Actual behavior (asserted deliberately): the shared PATCH handler checks
+    // edit authorization (author or DM) before any visibility guard, so a
+    // non-author member gets 403 — not the 404 the read-side visibility guard
+    // returns. This matches PATCH behavior for every other field (title,
+    // content, ...); the note's existence is only revealed to team members.
+    const otherApp = await createTestApp({ storage, authenticatedUser: otherMember });
+    const res = await request(otherApp.app)
+      .patch(`/api/teams/${teamId}/notes/${privateSession.id}`)
+      .send({ reviewedAt: "2026-07-06T12:00:00.000Z" })
+      .expect(403);
+    otherApp.server.close();
+    expect(res.body.message).toMatch(/not authorized/i);
+
+    // And the flag was not set
+    const stored = await storage.getNote(privateSession.id);
+    expect(stored?.reviewedAt ?? null).toBeNull();
+
+    // The author themselves can set it
+    const authorApp = await createTestApp({ storage, authenticatedUser: author });
+    const okRes = await request(authorApp.app)
+      .patch(`/api/teams/${teamId}/notes/${privateSession.id}`)
+      .send({ reviewedAt: "2026-07-06T12:00:00.000Z" })
+      .expect(200);
+    authorApp.server.close();
+    expect(new Date(okRes.body.reviewedAt).toISOString()).toBe(
+      "2026-07-06T12:00:00.000Z"
+    );
+  });
+});

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -15,6 +15,7 @@ import {
   type NoteType,
   type QuestStatus,
   type ImportVisibility,
+  type ImportRun,
   type ImportRunStats,
   type RelationshipType,
   type EvidenceType,
@@ -47,6 +48,20 @@ import {
   ENABLE_NUCLINO_LINK_EVIDENCE,
 } from "./feature-flags";
 import { canViewNote, filterVisibleNotes } from "./note-visibility";
+import {
+  resolveEmptyPageSelection,
+  filterPagesToImport,
+  completeImportRun,
+  markImportRunFailed,
+} from "./import-run-helpers";
+import {
+  makeListNotesHandler,
+  makeTodaySessionHandler,
+  makeNeedsReviewHandler,
+  makeCreateNoteHandler,
+  makeUpdateNoteHandler,
+  makeDeleteNoteHandler,
+} from "./notes-handlers";
 
 // PRD-050 FR-3: explicit Nuclino links are high-confidence evidence.
 const NUCLINO_LINK_EVIDENCE_CONFIDENCE = 0.9;
@@ -710,68 +725,13 @@ export async function registerRoutes(
   });
 
   // Get notes
-  app.get("/api/teams/:teamId/notes", isAuthenticated, async (req: any, res) => {
-    try {
-      const userId = req.user.claims.sub;
-      const { teamId } = req.params;
-
-      const member = await storage.getTeamMember(teamId, userId);
-      if (!member) {
-        return res.status(403).json({ message: "Not a team member" });
-      }
-
-      const notes = await storage.getNotes(teamId);
-      // P0-1 (F0/F48): never ship other authors' private notes to members
-      res.json(filterVisibleNotes(notes, userId, member.role));
-    } catch (error) {
-      console.error("Error fetching notes:", error);
-      res.status(500).json({ message: "Failed to fetch notes" });
-    }
-  });
+  app.get("/api/teams/:teamId/notes", isAuthenticated, makeListNotesHandler(storage));
 
   // PRD-019: Get today's session note
-  app.get("/api/teams/:teamId/notes/today-session", isAuthenticated, async (req: any, res) => {
-    try {
-      const userId = req.user.claims.sub;
-      const { teamId } = req.params;
-
-      const member = await storage.getTeamMember(teamId, userId);
-      if (!member) {
-        return res.status(403).json({ message: "Not a team member" });
-      }
-
-      const todaySession = await storage.findSessionByDate(teamId, new Date());
-      res.json(todaySession ?? null);
-    } catch (error) {
-      console.error("Error fetching today's session:", error);
-      res.status(500).json({ message: "Failed to fetch today's session" });
-    }
-  });
+  app.get("/api/teams/:teamId/notes/today-session", isAuthenticated, makeTodaySessionHandler(storage));
 
   // PRD-037: Get notes needing review (low-confidence AI classifications)
-  app.get("/api/teams/:teamId/notes/needs-review", isAuthenticated, async (req: any, res) => {
-    try {
-      const userId = req.user.claims.sub;
-      const { teamId } = req.params;
-
-      const member = await storage.getTeamMember(teamId, userId);
-      if (!member) {
-        return res.status(403).json({ message: "Not a team member" });
-      }
-
-      const items = await storage.getPendingLowConfidenceClassifications(teamId);
-      // P0-1 (F81): don't expose private notes' titles/explanations to non-authors
-      const teamNotes = await storage.getNotes(teamId);
-      const visibleNoteIds = new Set(
-        filterVisibleNotes(teamNotes, userId, member.role).map((note) => note.id),
-      );
-      const visibleItems = items.filter((item) => visibleNoteIds.has(item.noteId));
-      res.json({ items: visibleItems, count: visibleItems.length });
-    } catch (error) {
-      console.error("Error fetching needs-review items:", error);
-      res.status(500).json({ message: "Failed to fetch needs-review items" });
-    }
-  });
+  app.get("/api/teams/:teamId/notes/needs-review", isAuthenticated, makeNeedsReviewHandler(storage));
 
   // PRD-048: Single note detail endpoint with references and relationships
   app.get("/api/teams/:teamId/notes/:noteId", isAuthenticated, async (req: any, res) => {
@@ -999,112 +959,13 @@ export async function registerRoutes(
   });
 
   // Create note
-  app.post("/api/teams/:teamId/notes", isAuthenticated, async (req: any, res) => {
-    try {
-      const userId = req.user.claims.sub;
-      const { teamId } = req.params;
-      // PRD-034: Accept importRunId for suggestion-created entities to enable cascade delete
-      const { title, content, noteType, isPrivate, questStatus, contentBlocks, sessionDate, linkedNoteIds, importRunId } = req.body;
-
-      const member = await storage.getTeamMember(teamId, userId);
-      if (!member) {
-        return res.status(403).json({ message: "Not a team member" });
-      }
-
-      // For session_log type, check if one already exists for the given date (idempotency)
-      if (noteType === "session_log" && sessionDate) {
-        const existing = await storage.findSessionByDate(teamId, new Date(sessionDate));
-        if (existing) {
-          // P0-1 (F9): don't leak another author's private session content
-          if (!canViewNote(existing, userId, member.role)) {
-            return res.status(409).json({ message: "A private session already exists for this date" });
-          }
-          // Return existing session instead of creating duplicate
-          return res.status(200).json(existing);
-        }
-      }
-
-      const note = await storage.createNote({
-        teamId,
-        authorId: userId,
-        title,
-        content,
-        noteType,
-        isPrivate,
-        questStatus,
-        contentBlocks,
-        sessionDate: sessionDate ? new Date(sessionDate) : undefined,
-        linkedNoteIds,
-        importRunId: importRunId || undefined, // PRD-034: Track import origin for cascade delete
-      });
-
-      res.json(note);
-    } catch (error) {
-      console.error("Error creating note:", error);
-      res.status(500).json({ message: "Failed to create note" });
-    }
-  });
+  app.post("/api/teams/:teamId/notes", isAuthenticated, makeCreateNoteHandler(storage));
 
   // Update note
-  app.patch("/api/teams/:teamId/notes/:noteId", isAuthenticated, async (req: any, res) => {
-    try {
-      const userId = req.user.claims.sub;
-      const { teamId, noteId } = req.params;
-      
-      const member = await storage.getTeamMember(teamId, userId);
-      if (!member) {
-        return res.status(403).json({ message: "Not a team member" });
-      }
-
-      const existingNote = await storage.getNote(noteId);
-      if (!existingNote || existingNote.teamId !== teamId) {
-        return res.status(404).json({ message: "Note not found" });
-      }
-
-      if (existingNote.authorId !== userId && member.role !== "dm") {
-        return res.status(403).json({ message: "Not authorized to edit this note" });
-      }
-
-      const updateData = {
-        ...req.body,
-        sessionDate: req.body.sessionDate ? new Date(req.body.sessionDate) : req.body.sessionDate,
-      };
-
-      const note = await storage.updateNote(noteId, updateData);
-      res.json(note);
-    } catch (error) {
-      console.error("Error updating note:", error);
-      res.status(500).json({ message: "Failed to update note" });
-    }
-  });
+  app.patch("/api/teams/:teamId/notes/:noteId", isAuthenticated, makeUpdateNoteHandler(storage));
 
   // Delete note
-  app.delete("/api/teams/:teamId/notes/:noteId", isAuthenticated, async (req: any, res) => {
-    try {
-      const userId = req.user.claims.sub;
-      const { teamId, noteId } = req.params;
-
-      const member = await storage.getTeamMember(teamId, userId);
-      if (!member) {
-        return res.status(403).json({ message: "Not a team member" });
-      }
-
-      const existingNote = await storage.getNote(noteId);
-      if (!existingNote || existingNote.teamId !== teamId) {
-        return res.status(404).json({ message: "Note not found" });
-      }
-
-      if (existingNote.authorId !== userId && member.role !== "dm") {
-        return res.status(403).json({ message: "Not authorized to delete this note" });
-      }
-
-      await storage.deleteNote(noteId);
-      res.json({ success: true });
-    } catch (error) {
-      console.error("Error deleting note:", error);
-      res.status(500).json({ message: "Failed to delete note" });
-    }
-  });
+  app.delete("/api/teams/:teamId/notes/:noteId", isAuthenticated, makeDeleteNoteHandler(storage));
 
   // Get backlinks for a note (PRD-005)
   app.get("/api/teams/:teamId/notes/:noteId/backlinks", isAuthenticated, async (req: any, res) => {
@@ -1565,6 +1426,16 @@ export async function registerRoutes(
 
   // PRD-015: Nuclino Import - Commit import plan (updated for PRD-015A, PRD-030)
   app.post("/api/teams/:teamId/imports/nuclino/commit", isAuthenticated, async (req: any, res) => {
+    // P2-4 F51: track the active run and partial stats outside the try block so
+    // a mid-run crash records a truthful "failed" run instead of a phantom success.
+    let activeImportRun: ImportRun | null = null;
+    let totalPagesDetected = 0;
+    let created = 0;
+    let updated = 0;
+    let skipped = 0;
+    let linksResolved = 0;
+    let emptyPagesImported = 0;
+    const warnings: string[] = [];
     try {
       const userId = req.user.claims.sub;
       const { teamId } = req.params;
@@ -1594,25 +1465,17 @@ export async function registerRoutes(
         }
       }
 
-      // PRD-042: Support granular empty page exclusion with backward compatibility
-      let excludedEmptyPageIds: Set<string>;
-      let importEmptyPages: boolean;
-
-      if (options?.excludedEmptyPageIds && Array.isArray(options.excludedEmptyPageIds)) {
-        // New format: explicit list of empty page IDs to exclude
-        excludedEmptyPageIds = new Set(options.excludedEmptyPageIds);
-        // Derive importEmptyPages for record-keeping: true if no pages are excluded
-        importEmptyPages = excludedEmptyPageIds.size === 0;
-      } else {
-        // Legacy format: boolean importEmptyPages (defaults to true)
-        importEmptyPages = options?.importEmptyPages !== false;
-        excludedEmptyPageIds = importEmptyPages
-          ? new Set()
-          : new Set(plan.pages.filter(p => p.isEmpty).map(p => p.sourcePageId));
-      }
+      // PRD-042 / P2-4 F50: Support granular empty page exclusion with backward
+      // compatibility. importEmptyPages is true only when zero empty pages were
+      // actually excluded (see resolveEmptyPageSelection).
+      const { excludedEmptyPageIds, importEmptyPages } = resolveEmptyPageSelection(
+        plan.pages,
+        options,
+      );
       const defaultVisibility: ImportVisibility = options?.defaultVisibility || "private";
       const isPrivate = defaultVisibility === "private";
-      const pagesToImport = plan.pages.filter(p => !p.isEmpty || !excludedEmptyPageIds.has(p.sourcePageId));
+      const pagesToImport = filterPagesToImport(plan.pages, excludedEmptyPageIds);
+      totalPagesDetected = plan.summary.totalPages;
 
       // PRD-035: Use client-provided operation ID or generate one for progress tracking
       const commitOperationId = req.body.operationId || `commit-${teamId}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
@@ -1632,26 +1495,24 @@ export async function registerRoutes(
       }
 
       // PRD-015A: Create import run record FIRST
+      // P2-4 F51: the run starts "pending" and only becomes "completed" after
+      // all note-writing work has actually finished.
       const importRun = await storage.createImportRun({
         teamId,
         sourceSystem: "NUCLINO",
         createdByUserId: userId,
-        status: "completed",
+        status: "pending",
         options: {
           importEmptyPages,
           defaultVisibility,
         },
         stats: null, // Will update at end
       });
+      activeImportRun = importRun;
 
       // First pass: Create all notes to get their IDs
       const sourcePageIdToNoteId = new Map<string, string>();
       const noteTypeByNoteId = new Map<string, NoteType>();
-      let created = 0;
-      let updated = 0;
-      let skipped = 0;
-      let linksResolved = 0;
-      const warnings: string[] = [];
 
       // PRD-035: Initialize progress for creating phase
       updateImportProgress(commitOperationId, 'creating', 0, totalPages, 'Starting import...');
@@ -1737,6 +1598,11 @@ export async function registerRoutes(
             sourcePageIdToNoteId.set(page.sourcePageId, newNote.id);
             noteTypeByNoteId.set(newNote.id, noteType);
             created++;
+          }
+
+          // P2-4 F50: count empty pages that were ACTUALLY imported
+          if (page.isEmpty) {
+            emptyPagesImported++;
           }
         } catch (err) {
           console.error(`Error importing page ${page.title}:`, err);
@@ -1869,11 +1735,17 @@ export async function registerRoutes(
         notesCreated: created,
         notesUpdated: updated,
         notesSkipped: skipped,
-        emptyPagesImported: importEmptyPages ? plan.summary.emptyPages : 0,
+        // P2-4 F50: number of actually imported pages that were empty
+        // (supports PRD-042 partial empty-page selection)
+        emptyPagesImported,
         linksResolved,
         warningsCount: warnings.length,
       };
-      await storage.updateImportRun(importRun.id, { stats });
+      // P2-4 F51: note-writing work finished — the run is truthfully complete
+      await completeImportRun(storage, importRun.id, stats);
+      // Post-completion work (enrichment bookkeeping) must not flip the run to
+      // "failed": the notes are already written.
+      activeImportRun = null;
 
       // PRD-030: If using AI classifications, create enrichment run and store results
       let enrichmentRunId: string | null = null;
@@ -1975,6 +1847,19 @@ export async function registerRoutes(
       });
     } catch (error) {
       console.error("Error committing Nuclino import:", error);
+      // P2-4 F51: a crash mid-import must not leave a phantom "completed" (or
+      // stuck "pending") run — record it as failed with whatever stats we have.
+      if (activeImportRun) {
+        await markImportRunFailed(storage, activeImportRun.id, {
+          totalPagesDetected,
+          notesCreated: created,
+          notesUpdated: updated,
+          notesSkipped: skipped,
+          emptyPagesImported,
+          linksResolved,
+          warningsCount: warnings.length,
+        });
+      }
       res.status(500).json({ message: "Failed to commit import" });
     }
   });
@@ -2339,6 +2224,11 @@ export async function registerRoutes(
       // Get notes created by this import
       const notes = await storage.getNotesByImportRun(importId);
 
+      // P2-4 F49: snapshots identify pre-existing notes this run updated
+      // (vs. notes it created), so View Details can distinguish them.
+      const snapshots = await storage.getSnapshotsByImportRun(importId);
+      const updatedNoteIds = new Set(snapshots.map(s => s.noteId));
+
       // Get importer name
       const user = await storage.getUser(importRun.createdByUserId);
 
@@ -2347,7 +2237,12 @@ export async function registerRoutes(
         importerName: user
           ? `${user.firstName || ""} ${user.lastName || ""}`.trim() || user.email
           : "Unknown",
-        notes: notes.map(n => ({ id: n.id, title: n.title, noteType: n.noteType })),
+        notes: notes.map(n => ({
+          id: n.id,
+          title: n.title,
+          noteType: n.noteType,
+          wasUpdated: updatedNoteIds.has(n.id),
+        })),
       });
     } catch (error) {
       console.error("Error fetching import run:", error);

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -47,6 +47,9 @@ import {
   ENABLE_NUCLINO_LINK_EVIDENCE,
 } from "./feature-flags";
 
+// PRD-050 FR-3: explicit Nuclino links are high-confidence evidence.
+const NUCLINO_LINK_EVIDENCE_CONFIDENCE = 0.9;
+
 // PRD-015: Multer config for ZIP file uploads (store in memory)
 const upload = multer({
   storage: multer.memoryStorage(),
@@ -819,20 +822,42 @@ export async function registerRoutes(
         }
       }
 
-      const normalizedReferencesIn = referencesIn.map((reference) => {
-        const sourceNote = relatedNoteMap.get(reference.sourceNoteId);
-        const sourceVisible = sourceNote ? canViewNote(sourceNote, userId, member.role) : false;
-        return {
-          ...reference,
-          sourceNoteTitle: sourceVisible ? sourceNote?.title ?? null : null,
-          sourceNoteType: sourceVisible ? sourceNote?.noteType ?? null : null,
-          sourceNoteIsPrivate: sourceNote?.isPrivate ?? false,
-          textSnippet: sourceVisible ? reference.textSnippet : "Referenced in a private note",
-          snippetPreview: sourceVisible
-            ? toSnippetPreview(reference.textSnippet, "")
-            : "Referenced in a private note",
-        };
-      });
+      // PRD-048 FR-1b: include author names for reference entries
+      const teamMembersWithUsers = await storage.getTeamMembers(teamId);
+      const memberNameByUserId = new Map<string, string>();
+      for (const teamMember of teamMembersWithUsers) {
+        const name = [teamMember.user?.firstName, teamMember.user?.lastName]
+          .filter(Boolean)
+          .join(" ")
+          .trim();
+        memberNameByUserId.set(teamMember.userId, name || teamMember.user?.email || "Unknown");
+      }
+
+      const normalizedReferencesIn = referencesIn
+        .map((reference) => {
+          const sourceNote = relatedNoteMap.get(reference.sourceNoteId);
+          const sourceVisible = sourceNote ? canViewNote(sourceNote, userId, member.role) : false;
+          return {
+            ...reference,
+            sourceNoteTitle: sourceVisible ? sourceNote?.title ?? null : null,
+            sourceNoteType: sourceVisible ? sourceNote?.noteType ?? null : null,
+            sourceNoteIsPrivate: sourceNote?.isPrivate ?? false,
+            sourceNoteSessionDate: sourceVisible ? sourceNote?.sessionDate ?? null : null,
+            createdByName: reference.createdByUserId
+              ? memberNameByUserId.get(reference.createdByUserId) ?? null
+              : null,
+            textSnippet: sourceVisible ? reference.textSnippet : "Referenced in a private note",
+            snippetPreview: sourceVisible
+              ? toSnippetPreview(reference.textSnippet, "")
+              : "Referenced in a private note",
+          };
+        })
+        // PRD-048 FR-2: order by most recent session date, then creation time
+        .sort((a, b) => {
+          const aDate = a.sourceNoteSessionDate ?? a.createdAt;
+          const bDate = b.sourceNoteSessionDate ?? b.createdAt;
+          return new Date(bDate ?? 0).getTime() - new Date(aDate ?? 0).getTime();
+        });
 
       const normalizedReferencesOut = referencesOut.map((reference) => {
         const targetNote = relatedNoteMap.get(reference.targetNoteId);
@@ -1752,16 +1777,23 @@ export async function registerRoutes(
                 null,
               );
 
+              // PRD-050 FR-3: snippet is the markdown line containing the link.
+              const evidenceSnippet = (link.lineSnippet || link.text).slice(0, 500);
+
               if (ENABLE_NUCLINO_LINK_EVIDENCE) {
                 const fromType = noteTypeByNoteId.get(noteId) || "note";
                 const toType = noteTypeByNoteId.get(targetNoteId) || "note";
                 const inferred = inferRelationshipTypeForNoteTypes(fromType, toType);
+                // Honor the canonical direction (e.g. NPC page linking a Quest
+                // stores QuestHasNPC from the quest to the NPC).
+                const relationshipFromNoteId = inferred.swap ? targetNoteId : noteId;
+                const relationshipToNoteId = inferred.swap ? noteId : targetNoteId;
 
                 const existingRelationships = await storage.getRelationshipsForNote(noteId);
                 const existingRelationship = existingRelationships.find(
                   (relationship) =>
-                    relationship.fromNoteId === noteId &&
-                    relationship.toNoteId === targetNoteId &&
+                    relationship.fromNoteId === relationshipFromNoteId &&
+                    relationship.toNoteId === relationshipToNoteId &&
                     relationship.relationshipType === inferred.relationshipType &&
                     relationship.sourceNoteId === noteId &&
                     (relationship.sourceBlockId || "") === sourceBlockId,
@@ -1770,14 +1802,14 @@ export async function registerRoutes(
                 if (!existingRelationship) {
                   await storage.createNoteRelationship({
                     enrichmentRunId: null,
-                    fromNoteId: noteId,
-                    toNoteId: targetNoteId,
+                    fromNoteId: relationshipFromNoteId,
+                    toNoteId: relationshipToNoteId,
                     createdByUserId: userId,
                     sourceNoteId: noteId,
                     sourceBlockId,
                     relationshipType: inferred.relationshipType,
-                    confidence: 0.92,
-                    evidenceSnippet: link.text.slice(0, 500),
+                    confidence: NUCLINO_LINK_EVIDENCE_CONFIDENCE,
+                    evidenceSnippet,
                     evidenceType: "Link",
                     status: "approved",
                     approvedByUserId: userId,
@@ -1794,9 +1826,9 @@ export async function registerRoutes(
                 if (existingBacklink) {
                   await storage.updateBacklink(existingBacklink.id, {
                     sourceBlockId,
-                    textSnippet: link.text.slice(0, 500),
+                    textSnippet: evidenceSnippet,
                     evidenceType: "Link",
-                    confidence: 0.92,
+                    confidence: NUCLINO_LINK_EVIDENCE_CONFIDENCE,
                   });
                 } else {
                   await storage.createBacklink({
@@ -1804,9 +1836,9 @@ export async function registerRoutes(
                     sourceBlockId,
                     targetNoteId,
                     createdByUserId: userId,
-                    textSnippet: link.text.slice(0, 500),
+                    textSnippet: evidenceSnippet,
                     evidenceType: "Link",
-                    confidence: 0.92,
+                    confidence: NUCLINO_LINK_EVIDENCE_CONFIDENCE,
                   });
                 }
               }

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -46,6 +46,7 @@ import {
   ENABLE_ENTITY_DETAIL_ENDPOINT,
   ENABLE_NUCLINO_LINK_EVIDENCE,
 } from "./feature-flags";
+import { canViewNote, filterVisibleNotes } from "./note-visibility";
 
 // PRD-050 FR-3: explicit Nuclino links are high-confidence evidence.
 const NUCLINO_LINK_EVIDENCE_CONFIDENCE = 0.9;
@@ -159,10 +160,6 @@ export function updateImportProgress(
 
 const RELATIONSHIP_TYPE_SET = new Set<RelationshipType>(RELATIONSHIP_TYPES);
 const EVIDENCE_TYPE_SET = new Set<EvidenceType>(EVIDENCE_TYPES);
-
-function canViewNote(note: { isPrivate: boolean | null; authorId: string }, userId: string, role: "dm" | "member"): boolean {
-  return !note.isPrivate || note.authorId === userId || role === "dm";
-}
 
 function getSessionContent(note: {
   content?: string | null;
@@ -724,7 +721,8 @@ export async function registerRoutes(
       }
 
       const notes = await storage.getNotes(teamId);
-      res.json(notes);
+      // P0-1 (F0/F48): never ship other authors' private notes to members
+      res.json(filterVisibleNotes(notes, userId, member.role));
     } catch (error) {
       console.error("Error fetching notes:", error);
       res.status(500).json({ message: "Failed to fetch notes" });
@@ -762,7 +760,13 @@ export async function registerRoutes(
       }
 
       const items = await storage.getPendingLowConfidenceClassifications(teamId);
-      res.json({ items, count: items.length });
+      // P0-1 (F81): don't expose private notes' titles/explanations to non-authors
+      const teamNotes = await storage.getNotes(teamId);
+      const visibleNoteIds = new Set(
+        filterVisibleNotes(teamNotes, userId, member.role).map((note) => note.id),
+      );
+      const visibleItems = items.filter((item) => visibleNoteIds.has(item.noteId));
+      res.json({ items: visibleItems, count: visibleItems.length });
     } catch (error) {
       console.error("Error fetching needs-review items:", error);
       res.status(500).json({ message: "Failed to fetch needs-review items" });
@@ -1011,6 +1015,10 @@ export async function registerRoutes(
       if (noteType === "session_log" && sessionDate) {
         const existing = await storage.findSessionByDate(teamId, new Date(sessionDate));
         if (existing) {
+          // P0-1 (F9): don't leak another author's private session content
+          if (!canViewNote(existing, userId, member.role)) {
+            return res.status(409).json({ message: "A private session already exists for this date" });
+          }
           // Return existing session instead of creating duplicate
           return res.status(200).json(existing);
         }
@@ -2546,39 +2554,34 @@ export async function registerRoutes(
         return res.status(403).json({ message: "Not a team member" });
       }
 
-      // Get classification to verify team ownership
-      const classifications = await Promise.all(
-        (await storage.getNoteClassificationsByEnrichmentRun("")).map(async (c) => {
-          const enrichmentRun = await storage.getEnrichmentRun(c.enrichmentRunId);
-          return { ...c, teamId: enrichmentRun?.teamId };
-        })
+      // Get classification to verify team ownership (via this team's enrichment runs)
+      const allEnrichmentRuns = await Promise.all(
+        (await storage.getImportRuns(teamId)).map((ir) =>
+          storage.getEnrichmentRunByImportId(ir.id)
+        )
       );
 
-      const classification = classifications.find(
-        (c) => c.id === classificationId && c.teamId === teamId
-      );
+      type StoredClassification = Awaited<ReturnType<typeof storage.getNoteClassificationsByEnrichmentRun>>[number];
+      let classification: StoredClassification | undefined;
+      for (const er of allEnrichmentRuns) {
+        if (!er) continue;
+        const erClassifications = await storage.getNoteClassificationsByEnrichmentRun(er.id);
+        const match = erClassifications.find((c) => c.id === classificationId);
+        if (match) {
+          classification = match;
+          break;
+        }
+      }
 
       if (!classification) {
-        // Try to get it directly by looking up the note
-        const allEnrichmentRuns = await Promise.all(
-          (await storage.getImportRuns(teamId)).map((ir) =>
-            storage.getEnrichmentRunByImportId(ir.id)
-          )
-        );
+        return res.status(404).json({ message: "Classification not found" });
+      }
 
-        let found = false;
-        for (const er of allEnrichmentRuns) {
-          if (!er) continue;
-          const erClassifications = await storage.getNoteClassificationsByEnrichmentRun(er.id);
-          if (erClassifications.some((c) => c.id === classificationId)) {
-            found = true;
-            break;
-          }
-        }
-
-        if (!found) {
-          return res.status(404).json({ message: "Classification not found" });
-        }
+      // P0-1 (F81): members must not approve/reject/reclassify classifications
+      // belonging to another author's private note. 404 to avoid confirming existence.
+      const classifiedNote = await storage.getNote(classification.noteId);
+      if (!classifiedNote || classifiedNote.teamId !== teamId || !canViewNote(classifiedNote, userId, member.role)) {
+        return res.status(404).json({ message: "Classification not found" });
       }
 
       const updated = await storage.updateNoteClassificationStatus(classificationId, status, userId);

--- a/server/test/memory-storage.ts
+++ b/server/test/memory-storage.ts
@@ -349,6 +349,7 @@ export class MemoryStorage implements IStorage {
       authorId: note.authorId,
       title: note.title,
       content: note.content ?? null,
+      reviewedAt: note.reviewedAt ?? null,
       noteType,
       isPrivate: note.isPrivate ?? false,
       parentNoteId: note.parentNoteId ?? null,

--- a/server/test/test-routes.ts
+++ b/server/test/test-routes.ts
@@ -372,20 +372,42 @@ export async function registerTestRoutes(
         }
       }
 
-      const normalizedReferencesIn = referencesIn.map((reference) => {
-        const sourceNote = relatedById.get(reference.sourceNoteId);
-        const sourceVisible = sourceNote ? canViewNote(sourceNote, userId, member.role) : false;
-        return {
-          ...reference,
-          sourceNoteTitle: sourceVisible ? sourceNote?.title ?? null : null,
-          sourceNoteType: sourceVisible ? sourceNote?.noteType ?? null : null,
-          sourceNoteIsPrivate: sourceNote?.isPrivate ?? false,
-          textSnippet: sourceVisible ? reference.textSnippet : "Referenced in a private note",
-          snippetPreview: sourceVisible
-            ? toSnippetPreview(reference.textSnippet, "")
-            : "Referenced in a private note",
-        };
-      });
+      // PRD-048 FR-1b: include author names for reference entries
+      const teamMembersWithUsers = await storage.getTeamMembers(teamId);
+      const memberNameByUserId = new Map<string, string>();
+      for (const teamMember of teamMembersWithUsers) {
+        const name = [teamMember.user?.firstName, teamMember.user?.lastName]
+          .filter(Boolean)
+          .join(" ")
+          .trim();
+        memberNameByUserId.set(teamMember.userId, name || teamMember.user?.email || "Unknown");
+      }
+
+      const normalizedReferencesIn = referencesIn
+        .map((reference) => {
+          const sourceNote = relatedById.get(reference.sourceNoteId);
+          const sourceVisible = sourceNote ? canViewNote(sourceNote, userId, member.role) : false;
+          return {
+            ...reference,
+            sourceNoteTitle: sourceVisible ? sourceNote?.title ?? null : null,
+            sourceNoteType: sourceVisible ? sourceNote?.noteType ?? null : null,
+            sourceNoteIsPrivate: sourceNote?.isPrivate ?? false,
+            sourceNoteSessionDate: sourceVisible ? sourceNote?.sessionDate ?? null : null,
+            createdByName: reference.createdByUserId
+              ? memberNameByUserId.get(reference.createdByUserId) ?? null
+              : null,
+            textSnippet: sourceVisible ? reference.textSnippet : "Referenced in a private note",
+            snippetPreview: sourceVisible
+              ? toSnippetPreview(reference.textSnippet, "")
+              : "Referenced in a private note",
+          };
+        })
+        // PRD-048 FR-2: order by most recent session date, then creation time
+        .sort((a, b) => {
+          const aDate = a.sourceNoteSessionDate ?? a.createdAt;
+          const bDate = b.sourceNoteSessionDate ?? b.createdAt;
+          return new Date(bDate ?? 0).getTime() - new Date(aDate ?? 0).getTime();
+        });
 
       const normalizedReferencesOut = referencesOut.map((reference) => {
         const targetNote = relatedById.get(reference.targetNoteId);

--- a/server/test/test-routes.ts
+++ b/server/test/test-routes.ts
@@ -16,6 +16,14 @@ import { generateSessionCandidates } from "@shared/recurrence";
 import { buildCleanupSuggestions, type CleanupSuggestionMode } from "@shared/cleanup-suggestions";
 import { canonicalizeSourceBlockId } from "@shared/text-hash";
 import { canViewNote, filterVisibleNotes } from "../note-visibility";
+import {
+  makeListNotesHandler,
+  makeTodaySessionHandler,
+  makeNeedsReviewHandler,
+  makeCreateNoteHandler,
+  makeUpdateNoteHandler,
+  makeDeleteNoteHandler,
+} from "../notes-handlers";
 
 function generateInviteCode(): string {
   const chars = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
@@ -274,65 +282,13 @@ export async function registerTestRoutes(
     }
   });
 
-  app.get("/api/teams/:teamId/notes", isAuthenticated, async (req: any, res) => {
-    try {
-      const userId = req.user.claims.sub;
-      const { teamId } = req.params;
-
-      const member = await storage.getTeamMember(teamId, userId);
-      if (!member) {
-        return res.status(403).json({ message: "Not a team member" });
-      }
-
-      const notes = await storage.getNotes(teamId);
-      // P0-1 (F0/F48): shared predicate with production route (DM sees all)
-      res.json(filterVisibleNotes(notes, userId, member.role));
-    } catch (error) {
-      res.status(500).json({ message: "Failed to fetch notes" });
-    }
-  });
+  app.get("/api/teams/:teamId/notes", isAuthenticated, makeListNotesHandler(storage));
 
   // PRD-019: Get today's session note
-  app.get("/api/teams/:teamId/notes/today-session", isAuthenticated, async (req: any, res) => {
-    try {
-      const userId = req.user.claims.sub;
-      const { teamId } = req.params;
-
-      const member = await storage.getTeamMember(teamId, userId);
-      if (!member) {
-        return res.status(403).json({ message: "Not a team member" });
-      }
-
-      const todaySession = await storage.findSessionByDate(teamId, new Date());
-      res.json(todaySession ?? null);
-    } catch (error) {
-      res.status(500).json({ message: "Failed to fetch today's session" });
-    }
-  });
+  app.get("/api/teams/:teamId/notes/today-session", isAuthenticated, makeTodaySessionHandler(storage));
 
   // PRD-037: Get notes needing review (low-confidence AI classifications)
-  app.get("/api/teams/:teamId/notes/needs-review", isAuthenticated, async (req: any, res) => {
-    try {
-      const userId = req.user.claims.sub;
-      const { teamId } = req.params;
-
-      const member = await storage.getTeamMember(teamId, userId);
-      if (!member) {
-        return res.status(403).json({ message: "Not a team member" });
-      }
-
-      const items = await storage.getPendingLowConfidenceClassifications(teamId);
-      // P0-1 (F81): don't expose private notes' titles/explanations to non-authors
-      const teamNotes = await storage.getNotes(teamId);
-      const visibleNoteIds = new Set(
-        filterVisibleNotes(teamNotes, userId, member.role).map((note) => note.id),
-      );
-      const visibleItems = items.filter((item) => visibleNoteIds.has(item.noteId));
-      res.json({ items: visibleItems, count: visibleItems.length });
-    } catch (error) {
-      res.status(500).json({ message: "Failed to fetch needs-review items" });
-    }
-  });
+  app.get("/api/teams/:teamId/notes/needs-review", isAuthenticated, makeNeedsReviewHandler(storage));
 
   // PRD-037/PRD-038: Approve/reject/reclassify a low-confidence classification
   // (mirrors production route in server/routes.ts, including the P0-1/F81 privacy guard)
@@ -603,99 +559,11 @@ export async function registerTestRoutes(
     }
   });
 
-  app.post("/api/teams/:teamId/notes", isAuthenticated, async (req: any, res) => {
-    try {
-      const userId = req.user.claims.sub;
-      const { teamId } = req.params;
-      const { title, content, noteType, isPrivate, questStatus, contentBlocks, sessionDate, linkedNoteIds } = req.body;
+  app.post("/api/teams/:teamId/notes", isAuthenticated, makeCreateNoteHandler(storage));
 
-      const member = await storage.getTeamMember(teamId, userId);
-      if (!member) {
-        return res.status(403).json({ message: "Not a team member" });
-      }
+  app.patch("/api/teams/:teamId/notes/:noteId", isAuthenticated, makeUpdateNoteHandler(storage));
 
-      // PRD-023: For session_log type, check if one already exists for the given date (idempotency)
-      if (noteType === "session_log" && sessionDate) {
-        const existing = await storage.findSessionByDate(teamId, new Date(sessionDate));
-        if (existing) {
-          // P0-1 (F9): don't leak another author's private session content
-          if (!canViewNote(existing, userId, member.role)) {
-            return res.status(409).json({ message: "A private session already exists for this date" });
-          }
-          // Return existing session instead of creating duplicate
-          return res.status(200).json(existing);
-        }
-      }
-
-      const note = await storage.createNote({
-        teamId,
-        authorId: userId,
-        title,
-        content,
-        noteType,
-        isPrivate,
-        questStatus,
-        contentBlocks,
-        sessionDate: sessionDate ? new Date(sessionDate) : undefined,
-        linkedNoteIds,
-      });
-      res.json(note);
-    } catch (error) {
-      res.status(500).json({ message: "Failed to create note" });
-    }
-  });
-
-  app.patch("/api/teams/:teamId/notes/:noteId", isAuthenticated, async (req: any, res) => {
-    try {
-      const userId = req.user.claims.sub;
-      const { teamId, noteId } = req.params;
-
-      const member = await storage.getTeamMember(teamId, userId);
-      if (!member) {
-        return res.status(403).json({ message: "Not a team member" });
-      }
-
-      const note = await storage.getNote(noteId);
-      if (!note || note.teamId !== teamId) {
-        return res.status(404).json({ message: "Note not found" });
-      }
-
-      if (note.authorId !== userId && member.role !== "dm") {
-        return res.status(403).json({ message: "Can only edit your own notes" });
-      }
-
-      const updated = await storage.updateNote(noteId, req.body);
-      res.json(updated);
-    } catch (error) {
-      res.status(500).json({ message: "Failed to update note" });
-    }
-  });
-
-  app.delete("/api/teams/:teamId/notes/:noteId", isAuthenticated, async (req: any, res) => {
-    try {
-      const userId = req.user.claims.sub;
-      const { teamId, noteId } = req.params;
-
-      const member = await storage.getTeamMember(teamId, userId);
-      if (!member) {
-        return res.status(403).json({ message: "Not a team member" });
-      }
-
-      const note = await storage.getNote(noteId);
-      if (!note || note.teamId !== teamId) {
-        return res.status(404).json({ message: "Note not found" });
-      }
-
-      if (note.authorId !== userId && member.role !== "dm") {
-        return res.status(403).json({ message: "Can only delete your own notes" });
-      }
-
-      await storage.deleteNote(noteId);
-      res.json({ success: true });
-    } catch (error) {
-      res.status(500).json({ message: "Failed to delete note" });
-    }
-  });
+  app.delete("/api/teams/:teamId/notes/:noteId", isAuthenticated, makeDeleteNoteHandler(storage));
 
   app.get("/api/teams/:teamId/sessions", isAuthenticated, async (req: any, res) => {
     try {

--- a/server/test/test-routes.ts
+++ b/server/test/test-routes.ts
@@ -8,12 +8,14 @@ import {
   type TeamType,
   type AvailabilityStatus,
   type SessionStatus,
+  type NoteType,
   type RelationshipType,
   type EvidenceType,
 } from "@shared/schema";
 import { generateSessionCandidates } from "@shared/recurrence";
 import { buildCleanupSuggestions, type CleanupSuggestionMode } from "@shared/cleanup-suggestions";
 import { canonicalizeSourceBlockId } from "@shared/text-hash";
+import { canViewNote, filterVisibleNotes } from "../note-visibility";
 
 function generateInviteCode(): string {
   const chars = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
@@ -34,10 +36,6 @@ function rollDice(sides: number, count: number): number[] {
 
 const RELATIONSHIP_TYPE_SET = new Set<RelationshipType>(RELATIONSHIP_TYPES);
 const EVIDENCE_TYPE_SET = new Set<EvidenceType>(EVIDENCE_TYPES);
-
-function canViewNote(note: { isPrivate: boolean | null; authorId: string }, userId: string, role: "dm" | "member"): boolean {
-  return !note.isPrivate || note.authorId === userId || role === "dm";
-}
 
 function getSessionContent(note: { content?: string | null; contentBlocks?: Array<{ content: string }> | null }): string {
   if (note.content && note.content.trim().length > 0) {
@@ -287,8 +285,8 @@ export async function registerTestRoutes(
       }
 
       const notes = await storage.getNotes(teamId);
-      const filtered = notes.filter(n => !n.isPrivate || n.authorId === userId);
-      res.json(filtered);
+      // P0-1 (F0/F48): shared predicate with production route (DM sees all)
+      res.json(filterVisibleNotes(notes, userId, member.role));
     } catch (error) {
       res.status(500).json({ message: "Failed to fetch notes" });
     }
@@ -324,9 +322,91 @@ export async function registerTestRoutes(
       }
 
       const items = await storage.getPendingLowConfidenceClassifications(teamId);
-      res.json({ items, count: items.length });
+      // P0-1 (F81): don't expose private notes' titles/explanations to non-authors
+      const teamNotes = await storage.getNotes(teamId);
+      const visibleNoteIds = new Set(
+        filterVisibleNotes(teamNotes, userId, member.role).map((note) => note.id),
+      );
+      const visibleItems = items.filter((item) => visibleNoteIds.has(item.noteId));
+      res.json({ items: visibleItems, count: visibleItems.length });
     } catch (error) {
       res.status(500).json({ message: "Failed to fetch needs-review items" });
+    }
+  });
+
+  // PRD-037/PRD-038: Approve/reject/reclassify a low-confidence classification
+  // (mirrors production route in server/routes.ts, including the P0-1/F81 privacy guard)
+  app.patch("/api/teams/:teamId/classifications/:classificationId", isAuthenticated, async (req: any, res) => {
+    try {
+      const userId = req.user.claims.sub;
+      const { teamId, classificationId } = req.params;
+      const { status, overrideType } = req.body;
+
+      if (!["approved", "rejected"].includes(status)) {
+        return res.status(400).json({ message: "Invalid status" });
+      }
+
+      const validTypes = ["Character", "NPC", "Area", "POI", "Quest", "SessionLog", "Note"];
+      if (overrideType && !validTypes.includes(overrideType)) {
+        return res.status(400).json({ message: "Invalid override type" });
+      }
+
+      const member = await storage.getTeamMember(teamId, userId);
+      if (!member) {
+        return res.status(403).json({ message: "Not a team member" });
+      }
+
+      // Get classification to verify team ownership (via this team's enrichment runs)
+      const allEnrichmentRuns = await Promise.all(
+        (await storage.getImportRuns(teamId)).map((ir) =>
+          storage.getEnrichmentRunByImportId(ir.id)
+        )
+      );
+
+      type StoredClassification = Awaited<ReturnType<typeof storage.getNoteClassificationsByEnrichmentRun>>[number];
+      let classification: StoredClassification | undefined;
+      for (const er of allEnrichmentRuns) {
+        if (!er) continue;
+        const erClassifications = await storage.getNoteClassificationsByEnrichmentRun(er.id);
+        const match = erClassifications.find((c) => c.id === classificationId);
+        if (match) {
+          classification = match;
+          break;
+        }
+      }
+
+      if (!classification) {
+        return res.status(404).json({ message: "Classification not found" });
+      }
+
+      // P0-1 (F81): members must not approve/reject/reclassify classifications
+      // belonging to another author's private note. 404 to avoid confirming existence.
+      const classifiedNote = await storage.getNote(classification.noteId);
+      if (!classifiedNote || classifiedNote.teamId !== teamId || !canViewNote(classifiedNote, userId, member.role)) {
+        return res.status(404).json({ message: "Classification not found" });
+      }
+
+      const updated = await storage.updateNoteClassificationStatus(classificationId, status, userId);
+
+      // If approved, update the note's type (PRD-038: overrideType wins)
+      if (status === "approved") {
+        const noteTypeMap: Record<string, string> = {
+          Character: "character",
+          NPC: "npc",
+          Area: "area",
+          POI: "poi",
+          Quest: "quest",
+          SessionLog: "session_log",
+          Note: "note",
+        };
+        const typeToUse = overrideType || updated.inferredType;
+        const newNoteType = noteTypeMap[typeToUse] || "note";
+        await storage.updateNote(updated.noteId, { noteType: newNoteType as NoteType });
+      }
+
+      res.json(updated);
+    } catch (error) {
+      res.status(500).json({ message: "Failed to update classification" });
     }
   });
 
@@ -538,6 +618,10 @@ export async function registerTestRoutes(
       if (noteType === "session_log" && sessionDate) {
         const existing = await storage.findSessionByDate(teamId, new Date(sessionDate));
         if (existing) {
+          // P0-1 (F9): don't leak another author's private session content
+          if (!canViewNote(existing, userId, member.role)) {
+            return res.status(409).json({ message: "A private session already exists for this date" });
+          }
           // Return existing session instead of creating duplicate
           return res.status(200).json(existing);
         }

--- a/shared/cleanup-suggestions.test.ts
+++ b/shared/cleanup-suggestions.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildCleanupSuggestions,
+  buildFirstSeenSeed,
+  confidenceBucket,
+  inferRelationshipTypeForNoteTypes,
+} from "./cleanup-suggestions";
+import type { Note } from "./schema";
+
+function makeNote(overrides: Partial<Note> & Pick<Note, "id" | "title" | "noteType">): Note {
+  return {
+    teamId: "team-1",
+    authorId: "user-1",
+    content: "",
+    contentBlocks: null,
+    isPrivate: false,
+    sessionDate: null,
+    questStatus: null,
+    sourceSystem: null,
+    sourcePageId: null,
+    contentMarkdown: null,
+    contentMarkdownResolved: null,
+    importRunId: null,
+    createdByUserId: null,
+    updatedByUserId: null,
+    createdAt: new Date("2026-01-01T00:00:00Z"),
+    updatedAt: new Date("2026-01-01T00:00:00Z"),
+    ...overrides,
+  } as Note;
+}
+
+const SESSION_CONTENT =
+  "We met Lord Blackwood in Silverwood Forest. He asked us to Find the Lost Relic before nightfall.";
+
+describe("confidenceBucket (PRD-049 FR-5)", () => {
+  it("labels HIGH at 0.80 and above", () => {
+    expect(confidenceBucket(0.8)).toBe("HIGH");
+    expect(confidenceBucket(0.95)).toBe("HIGH");
+  });
+
+  it("labels REVIEW between 0.65 and 0.79", () => {
+    expect(confidenceBucket(0.65)).toBe("REVIEW");
+    expect(confidenceBucket(0.79)).toBe("REVIEW");
+  });
+
+  it("labels LOW below 0.65", () => {
+    expect(confidenceBucket(0.64)).toBe("LOW");
+    expect(confidenceBucket(0.5)).toBe("LOW");
+  });
+});
+
+describe("inferRelationshipTypeForNoteTypes (PRD-049/PRD-050)", () => {
+  it("maps quest -> npc to QuestHasNPC", () => {
+    expect(inferRelationshipTypeForNoteTypes("quest", "npc")).toEqual({
+      relationshipType: "QuestHasNPC",
+      swap: false,
+    });
+  });
+
+  it("swaps npc -> quest so the quest is the from side", () => {
+    expect(inferRelationshipTypeForNoteTypes("npc", "quest")).toEqual({
+      relationshipType: "QuestHasNPC",
+      swap: true,
+    });
+  });
+
+  it("maps quest -> area/poi to QuestAtPlace", () => {
+    expect(inferRelationshipTypeForNoteTypes("quest", "area")).toEqual({
+      relationshipType: "QuestAtPlace",
+      swap: false,
+    });
+    expect(inferRelationshipTypeForNoteTypes("poi", "quest")).toEqual({
+      relationshipType: "QuestAtPlace",
+      swap: true,
+    });
+  });
+
+  it("maps npc/character -> area/poi to NPCInPlace", () => {
+    expect(inferRelationshipTypeForNoteTypes("npc", "area")).toEqual({
+      relationshipType: "NPCInPlace",
+      swap: false,
+    });
+    expect(inferRelationshipTypeForNoteTypes("area", "character")).toEqual({
+      relationshipType: "NPCInPlace",
+      swap: true,
+    });
+  });
+
+  it("falls back to Related for other combinations", () => {
+    expect(inferRelationshipTypeForNoteTypes("note", "note")).toEqual({
+      relationshipType: "Related",
+      swap: false,
+    });
+  });
+});
+
+describe("buildFirstSeenSeed (PRD-048 FR-4)", () => {
+  it("builds a First seen section with session label and snippet", () => {
+    const seed = buildFirstSeenSeed("2026-02-17", "Kettle greeted the party warmly.");
+    expect(seed).toBe(
+      '## First seen\n- Session 2026-02-17: "Kettle greeted the party warmly."'
+    );
+  });
+
+  it("truncates long snippets", () => {
+    const seed = buildFirstSeenSeed("2026-02-17", "x".repeat(500));
+    expect(seed.length).toBeLessThan(300);
+    expect(seed).toContain("...");
+  });
+});
+
+describe("buildCleanupSuggestions (PRD-049)", () => {
+  it("generates relationship suggestions for co-occurring entities", () => {
+    const result = buildCleanupSuggestions({
+      content: SESSION_CONTENT,
+      existingNotes: [
+        makeNote({ id: "npc-1", title: "Lord Blackwood", noteType: "npc" }),
+        makeNote({ id: "area-1", title: "Silverwood Forest", noteType: "area" }),
+      ],
+      includeLow: true,
+      mode: "baseline",
+    });
+
+    expect(result.relationshipSuggestions.length).toBeGreaterThan(0);
+
+    const npcInPlace = result.relationshipSuggestions.find(
+      (s) => s.relationshipType === "NPCInPlace"
+    );
+    expect(npcInPlace).toBeDefined();
+    expect(npcInPlace!.fromNoteId).toBe("npc-1");
+    expect(npcInPlace!.toNoteId).toBe("area-1");
+    expect(npcInPlace!.snippetText.length).toBeGreaterThan(0);
+    expect(npcInPlace!.evidenceType).toBe("Mention");
+    expect(["HIGH", "REVIEW", "LOW"]).toContain(npcInPlace!.confidenceBucket);
+  });
+
+  it("marks suggestions with unmatched entities as requiring resolution", () => {
+    const result = buildCleanupSuggestions({
+      content: SESSION_CONTENT,
+      existingNotes: [],
+      includeLow: true,
+      mode: "baseline",
+    });
+
+    for (const suggestion of result.relationshipSuggestions) {
+      expect(suggestion.requiresResolution).toBe(true);
+      expect(suggestion.fromNoteId).toBeNull();
+    }
+  });
+
+  it("detects quest promotion suggestions from actionable text (PRD-049 FR-3)", () => {
+    const result = buildCleanupSuggestions({
+      content: SESSION_CONTENT,
+      existingNotes: [
+        makeNote({ id: "npc-1", title: "Lord Blackwood", noteType: "npc" }),
+        makeNote({ id: "area-1", title: "Silverwood Forest", noteType: "area" }),
+      ],
+      includeLow: true,
+      mode: "baseline",
+    });
+
+    expect(result.questSuggestions.length).toBeGreaterThan(0);
+    const quest = result.questSuggestions[0];
+    expect(quest.proposedQuestTitle).toMatch(/^Find Lost Relic/);
+    expect(quest.snippetText).toContain("Find the Lost Relic");
+    // Nearest known NPC/Area are suggested for auto-linking
+    expect(quest.suggestedNpcNoteId).toBe("npc-1");
+    expect(quest.suggestedAreaNoteId).toBe("area-1");
+  });
+
+  it("matches existing quests by title overlap", () => {
+    const result = buildCleanupSuggestions({
+      content: SESSION_CONTENT,
+      existingNotes: [
+        makeNote({ id: "quest-1", title: "Find Lost Relic", noteType: "quest" }),
+      ],
+      includeLow: true,
+      mode: "baseline",
+    });
+
+    const quest = result.questSuggestions[0];
+    expect(quest.existingQuestMatches.map((m) => m.id)).toContain("quest-1");
+  });
+
+  it("is deterministic for the same input", () => {
+    const input = {
+      content: SESSION_CONTENT,
+      existingNotes: [
+        makeNote({ id: "npc-1", title: "Lord Blackwood", noteType: "npc" }),
+      ],
+      includeLow: true,
+      mode: "baseline" as const,
+    };
+
+    const first = buildCleanupSuggestions(input);
+    const second = buildCleanupSuggestions(input);
+
+    expect(first.sourceContentHash).toBe(second.sourceContentHash);
+    expect(first.relationshipSuggestions.map((s) => s.id)).toEqual(
+      second.relationshipSuggestions.map((s) => s.id)
+    );
+    expect(first.questSuggestions.map((s) => s.id)).toEqual(
+      second.questSuggestions.map((s) => s.id)
+    );
+  });
+});

--- a/shared/cleanup-suggestions.test.ts
+++ b/shared/cleanup-suggestions.test.ts
@@ -168,6 +168,23 @@ describe("buildCleanupSuggestions (PRD-049)", () => {
     expect(quest.suggestedAreaNoteId).toBe("area-1");
   });
 
+  it("detects quest promotion from natural-prose action phrases (gap F13)", () => {
+    const result = buildCleanupSuggestions({
+      content: "The innkeeper asked us to find the missing caravan. Also, we need to defeat the bandits soon.",
+      existingNotes: [],
+      includeLow: true,
+      mode: "baseline",
+    });
+
+    const titles = result.questSuggestions.map((s) => s.proposedQuestTitle.toLowerCase());
+    expect(titles.some((t) => t.includes("find") && t.includes("missing caravan"))).toBe(true);
+    expect(titles.some((t) => t.includes("defeat") && t.includes("bandits"))).toBe(true);
+    // Presentable title casing
+    for (const s of result.questSuggestions) {
+      expect(s.proposedQuestTitle.charAt(0)).toBe(s.proposedQuestTitle.charAt(0).toUpperCase());
+    }
+  });
+
   it("matches existing quests by title overlap", () => {
     const result = buildCleanupSuggestions({
       content: SESSION_CONTENT,

--- a/shared/cleanup-suggestions.ts
+++ b/shared/cleanup-suggestions.ts
@@ -80,6 +80,9 @@ export function buildFirstSeenSeed(sessionLabel: string, snippet: string): strin
 const QUEST_ACTION_PATTERNS = [
   /\b(Find|Defeat|Retrieve|Rescue|Discover|Destroy|Recover|Investigate|Escort)\s+the\s+([A-Za-z][^.!?\n]{2,90})/g,
   /\b(Find|Defeat|Retrieve|Rescue|Discover|Destroy|Recover|Investigate|Escort)\s+([A-Z][A-Za-z0-9' -]{2,90})/g,
+  // PRD-002 FR-2 / gap F13: natural-prose action phrases in normal session prose,
+  // e.g. "she asked us to find the artifact", "we need to defeat the dragon".
+  /\b(?:need(?:s)? to|asked (?:us|me|them) to|must|have to|has to|were told to)\s+(find|defeat|retrieve|rescue|discover|destroy|recover|investigate|escort)\s+(?:the\s+)?([a-z][^.!?\n]{2,90})/gi,
 ];
 
 function toSlug(value: string): string {
@@ -327,7 +330,9 @@ function buildQuestSuggestions(
     while ((match = pattern.exec(content)) !== null) {
       const verb = match[1].trim();
       const subject = match[2].trim().replace(/[.,;:!?]+$/, "");
-      const title = `${verb} ${subject}`.replace(/\s+/g, " ").trim();
+      const rawTitle = `${verb} ${subject}`.replace(/\s+/g, " ").trim();
+      // Prose-derived matches are lowercase; capitalize for a presentable quest title.
+      const title = rawTitle.charAt(0).toUpperCase() + rawTitle.slice(1);
       const titleKey = title.toLowerCase();
       if (!title || seenTitles.has(titleKey)) continue;
       seenTitles.add(titleKey);

--- a/shared/cleanup-suggestions.ts
+++ b/shared/cleanup-suggestions.ts
@@ -67,6 +67,16 @@ export interface BuildCleanupSuggestionsInput {
   mode: CleanupSuggestionMode;
 }
 
+/**
+ * PRD-048 FR-4: seed content for entities created from session mentions so new
+ * entity pages are never blank. Only intended for use when content is empty.
+ */
+export function buildFirstSeenSeed(sessionLabel: string, snippet: string): string {
+  const trimmed = snippet.trim();
+  const truncated = trimmed.length > 240 ? `${trimmed.slice(0, 237)}...` : trimmed;
+  return `## First seen\n- Session ${sessionLabel}: "${truncated}"`;
+}
+
 const QUEST_ACTION_PATTERNS = [
   /\b(Find|Defeat|Retrieve|Rescue|Discover|Destroy|Recover|Investigate|Escort)\s+the\s+([A-Za-z][^.!?\n]{2,90})/g,
   /\b(Find|Defeat|Retrieve|Rescue|Discover|Destroy|Recover|Investigate|Escort)\s+([A-Z][A-Za-z0-9' -]{2,90})/g,
@@ -87,7 +97,7 @@ function confidenceValue(level: "high" | "medium" | "low"): number {
   return 0.58;
 }
 
-function confidenceBucket(confidence: number): ConfidenceBucket {
+export function confidenceBucket(confidence: number): ConfidenceBucket {
   if (confidence >= 0.8) return "HIGH";
   if (confidence >= 0.65) return "REVIEW";
   return "LOW";

--- a/shared/entity-detection.test.ts
+++ b/shared/entity-detection.test.ts
@@ -580,4 +580,65 @@ describe("Entity Detection (PRD-002)", () => {
       expect(captainEntities[0].normalizedText).toBe("captain garner");
     });
   });
+
+  describe("P0-2: Stable entity IDs (PRD-022 FR-7/FR-9)", () => {
+    it("assigns identical IDs across repeated detection runs on the same content", () => {
+      const text = "Lord Blackwood met us near The Silverwood Forest.";
+      const first = detectEntities(text);
+      const second = detectEntities(text);
+
+      expect(first.length).toBeGreaterThan(0);
+      expect(first.map((e) => e.id)).toEqual(second.map((e) => e.id));
+    });
+
+    it("keeps an entity's ID stable when unrelated content is appended", () => {
+      const base = "Lord Blackwood greeted the party.";
+      const extended = base + " Later we rested at camp and talked for hours.";
+
+      const findBlackwood = (entities: ReturnType<typeof detectEntities>) =>
+        entities.find((e) => e.normalizedText === "lord blackwood");
+
+      const before = findBlackwood(detectEntities(base));
+      const after = findBlackwood(detectEntities(extended));
+      expect(before).toBeDefined();
+      expect(after).toBeDefined();
+      expect(after!.id).toBe(before!.id);
+    });
+
+    it("derives IDs from type and normalized text", () => {
+      const entities = detectEntities("Lord Blackwood arrived.");
+      const blackwood = entities.find((e) => e.normalizedText === "lord blackwood");
+      expect(blackwood!.id).toBe("entity-npc-lord-blackwood");
+    });
+  });
+
+  describe("P0-5: Natural-prose quest detection (PRD-002 FR-2)", () => {
+    it("detects 'asked us to find the artifact'", () => {
+      const entities = detectEntities("The old sage asked us to find the artifact before dawn.");
+      const quest = entities.find((e) => e.type === "quest");
+      expect(quest).toBeDefined();
+      expect(quest!.normalizedText).toContain("find");
+      expect(quest!.normalizedText).toContain("artifact");
+    });
+
+    it("detects 'We need to defeat the dragon'", () => {
+      const entities = detectEntities("We need to defeat the dragon terrorizing the valley");
+      const quest = entities.find((e) => e.type === "quest");
+      expect(quest).toBeDefined();
+      expect(quest!.normalizedText).toContain("defeat");
+      expect(quest!.normalizedText).toContain("dragon");
+    });
+
+    it("detects 'must retrieve' phrasing", () => {
+      const entities = detectEntities("The party must retrieve the stolen ledger from the docks");
+      const quest = entities.find((e) => e.type === "quest");
+      expect(quest).toBeDefined();
+      expect(quest!.normalizedText).toContain("retrieve");
+    });
+
+    it("still detects the capitalized quest forms", () => {
+      const entities = detectEntities("Our Quest for the Lost Crown continues.");
+      expect(entities.some((e) => e.type === "quest")).toBe(true);
+    });
+  });
 });

--- a/shared/entity-detection.ts
+++ b/shared/entity-detection.ts
@@ -93,13 +93,21 @@ const QUEST_PATTERNS = [
   /\b(Quest|Mission|Task|Hunt|Search|Journey)\s+(?:for|to|of)\s+(?:the\s+)?([A-Z][a-z]+(?:\s+[A-Z][a-z]+)*)/g,
   // "Find/Defeat/Retrieve the X" patterns
   /\b(Find|Defeat|Retrieve|Rescue|Discover|Destroy|Recover)\s+the\s+([A-Z][a-z]+(?:\s+[A-Z][a-z]+)*)/g,
+  // PRD-002 FR-2: natural-prose action phrases ("we need to defeat the dragon",
+  // "asked us to find the artifact"). Case-insensitive; the trigger phrase stays
+  // outside the match via lookbehind so the suggestion text starts at the verb.
+  /(?<=\b(?:need(?:s)? to|asked (?:us|me|them) to|must|have to|has to|were told to)\s)(?:find|defeat|retrieve|rescue|discover|destroy|recover|investigate|escort)\s+(?:the\s+)?[a-z][^.!?\n,;:]{2,60}/gi,
 ];
 
 // Proper noun pattern (capitalized words not at sentence start)
 const PROPER_NOUN_PATTERN = /(?<=[.!?]\s+|^)([A-Z][a-z]+)|(?<=[a-z]\s)([A-Z][a-z]+(?:\s+[A-Z][a-z]+)*)/g;
 
-function generateEntityId(): string {
-  return `entity-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+// PRD-022 FR-7/FR-9: IDs must be stable across detection runs so dismissed /
+// reclassified / created state persisted in localStorage keeps matching. Derive
+// the ID from the entity's identity instead of minting a random one per run.
+function generateEntityId(type: EntityType, normalizedText: string): string {
+  const slug = normalizedText.replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "") || "entity";
+  return `entity-${type}-${slug}`;
 }
 
 function normalizeText(text: string): string {
@@ -444,7 +452,7 @@ export function detectEntities(
       }
     } else {
       entityMap.set(normalized, {
-        id: generateEntityId(),
+        id: generateEntityId(match.type, normalized),
         type: match.type,
         text: match.text,
         normalizedText: normalized,

--- a/shared/nuclino-parser.test.ts
+++ b/shared/nuclino-parser.test.ts
@@ -172,6 +172,7 @@ describe("extractNuclinoLinks", () => {
       targetFilename: "Kettle 03183b35.md",
       targetPageId: "03183b35",
       fullMatch: "[Kettle](<Kettle 03183b35.md?n>)",
+      lineSnippet: "See [Kettle](<Kettle 03183b35.md?n>) for more info.",
     });
   });
 
@@ -671,8 +672,8 @@ describe("summarizeNuclinoLinks", () => {
         content: "",
         contentRaw: "",
         links: [
-          { text: "B", targetFilename: "B 22222222.md", targetPageId: "22222222", fullMatch: "" },
-          { text: "C", targetFilename: "C 33333333.md", targetPageId: "33333333", fullMatch: "" },
+          { text: "B", targetFilename: "B 22222222.md", targetPageId: "22222222", fullMatch: "", lineSnippet: "" },
+          { text: "C", targetFilename: "C 33333333.md", targetPageId: "33333333", fullMatch: "", lineSnippet: "" },
         ],
         isEmpty: false,
       },
@@ -683,7 +684,7 @@ describe("summarizeNuclinoLinks", () => {
         content: "",
         contentRaw: "",
         links: [
-          { text: "C", targetFilename: "C 33333333.md", targetPageId: "33333333", fullMatch: "" },
+          { text: "C", targetFilename: "C 33333333.md", targetPageId: "33333333", fullMatch: "", lineSnippet: "" },
         ],
         isEmpty: false,
       },
@@ -693,6 +694,114 @@ describe("summarizeNuclinoLinks", () => {
     expect(stats.totalLinks).toBe(3);
     expect(stats.pagesWithLinks).toBe(2);
     expect(stats.uniqueTargetPages).toBe(2);
+  });
+
+  // PRD-050 FR-5: link resolution stats
+  it("counts resolved and unresolved links against known pages", () => {
+    const pages: NuclinoPage[] = [
+      {
+        filename: "A 11111111.md",
+        sourcePageId: "11111111",
+        title: "A",
+        content: "",
+        contentRaw: "",
+        links: [
+          // B exists in the export -> resolved
+          { text: "B", targetFilename: "B 22222222.md", targetPageId: "22222222", fullMatch: "", lineSnippet: "" },
+          // Missing page -> unresolved (twice, to test counting)
+          { text: "Ghost", targetFilename: "Ghost 99999999.md", targetPageId: "99999999", fullMatch: "", lineSnippet: "" },
+          { text: "Ghost", targetFilename: "Ghost 99999999.md", targetPageId: "99999999", fullMatch: "", lineSnippet: "" },
+        ],
+        isEmpty: false,
+      },
+      {
+        filename: "B 22222222.md",
+        sourcePageId: "22222222",
+        title: "B",
+        content: "",
+        contentRaw: "",
+        links: [],
+        isEmpty: false,
+      },
+    ];
+
+    const stats = summarizeNuclinoLinks(pages);
+    expect(stats.resolvedLinks).toBe(1);
+    expect(stats.unresolvedLinks).toBe(2);
+    expect(stats.topUnresolvedTargets).toEqual([
+      { target: "Ghost 99999999.md", count: 2 },
+    ]);
+  });
+
+  it("caps topUnresolvedTargets at 10 sorted by count", () => {
+    const links = Array.from({ length: 15 }, (_, i) => {
+      const id = `${i}`.padStart(8, "a");
+      return {
+        text: `Missing ${i}`,
+        targetFilename: `Missing ${i} ${id}.md`,
+        targetPageId: id,
+        fullMatch: "",
+        lineSnippet: "",
+      };
+    });
+    const pages: NuclinoPage[] = [
+      {
+        filename: "A 11111111.md",
+        sourcePageId: "11111111",
+        title: "A",
+        content: "",
+        contentRaw: "",
+        links,
+        isEmpty: false,
+      },
+    ];
+
+    const stats = summarizeNuclinoLinks(pages);
+    expect(stats.unresolvedLinks).toBe(15);
+    expect(stats.topUnresolvedTargets).toHaveLength(10);
+  });
+});
+
+describe("PRD-050 link evidence extraction", () => {
+  it("captures the markdown line containing the link as lineSnippet", () => {
+    const content = [
+      "# Heading",
+      "Intro paragraph.",
+      "- The party should visit [Kettle](<Kettle 03183b35.md?n>) at the tavern.",
+      "Closing line.",
+    ].join("\n");
+
+    const links = extractNuclinoLinks(content);
+    expect(links).toHaveLength(1);
+    expect(links[0].lineSnippet).toBe(
+      "- The party should visit [Kettle](<Kettle 03183b35.md?n>) at the tavern."
+    );
+  });
+
+  it("truncates very long lines in lineSnippet", () => {
+    const longPrefix = "x".repeat(300);
+    const content = `${longPrefix} [Kettle](<Kettle 03183b35.md?n>)`;
+    const links = extractNuclinoLinks(content);
+    expect(links).toHaveLength(1);
+    expect(links[0].lineSnippet.length).toBeLessThanOrEqual(240);
+    expect(links[0].lineSnippet.endsWith("...")).toBe(true);
+  });
+
+  it("never leaves angle brackets or ?n in normalized targets (FR-1 invariant)", () => {
+    const adversarialTargets = [
+      "<Kettle 03183b35.md?n>",
+      "Kettle 03183b35.md?n",
+      "./Kettle%2003183b35.md",
+      "<Some%20Page%20abcdef12.md?n>",
+    ];
+
+    for (const target of adversarialTargets) {
+      const links = extractNuclinoLinks(`[Text](${target})`);
+      expect(links).toHaveLength(1);
+      expect(links[0].targetFilename).not.toMatch(/[<>]/);
+      expect(links[0].targetFilename).not.toContain("?n");
+      expect(links[0].targetPageId).toMatch(/^[a-f0-9]{8}$/);
+    }
   });
 });
 

--- a/shared/nuclino-parser.ts
+++ b/shared/nuclino-parser.ts
@@ -12,6 +12,8 @@ export interface NuclinoLink {
   targetFilename: string;
   targetPageId: string;
   fullMatch: string;
+  /** The markdown line containing the link, truncated (PRD-050 evidence snippet). */
+  lineSnippet: string;
 }
 
 export interface NuclinoPage {
@@ -52,6 +54,12 @@ export interface NuclinoLinkStats {
   totalLinks: number;
   pagesWithLinks: number;
   uniqueTargetPages: number;
+  /** PRD-050: links whose target page exists in the export. */
+  resolvedLinks: number;
+  /** PRD-050: links whose target page is not in the export. */
+  unresolvedLinks: number;
+  /** PRD-050: most frequent unresolved link targets (up to 10). */
+  topUnresolvedTargets: Array<{ target: string; count: number }>;
 }
 
 // Known collection page names for auto-detection
@@ -212,6 +220,21 @@ function parseTargetPageId(target: string): string | null {
  * Nuclino links look like: [Link Text](<Some Page abc12345.md?n>)
  * The ?n suffix and angle brackets are Nuclino-specific.
  */
+const LINE_SNIPPET_MAX_LENGTH = 240;
+
+/**
+ * Extract the full markdown line containing a match, truncated for storage.
+ */
+function extractLineSnippet(content: string, matchIndex: number): string {
+  const lineStart = content.lastIndexOf("\n", matchIndex) + 1;
+  const lineEndIndex = content.indexOf("\n", matchIndex);
+  const lineEnd = lineEndIndex === -1 ? content.length : lineEndIndex;
+  const line = content.slice(lineStart, lineEnd).trim();
+  return line.length > LINE_SNIPPET_MAX_LENGTH
+    ? `${line.slice(0, LINE_SNIPPET_MAX_LENGTH - 3)}...`
+    : line;
+}
+
 export function extractNuclinoLinks(content: string): NuclinoLink[] {
   const links: NuclinoLink[] = [];
 
@@ -238,6 +261,7 @@ export function extractNuclinoLinks(content: string): NuclinoLink[] {
       targetFilename: filenameWithoutQuery,
       targetPageId,
       fullMatch,
+      lineSnippet: extractLineSnippet(content, match.index),
     });
   }
 
@@ -467,8 +491,12 @@ export function resolveNuclinoLinks(
 
 export function summarizeNuclinoLinks(pages: NuclinoPage[]): NuclinoLinkStats {
   const targetPages = new Set<string>();
+  const knownPageIds = new Set(pages.map((page) => page.sourcePageId));
+  const unresolvedCounts = new Map<string, number>();
   let totalLinks = 0;
   let pagesWithLinks = 0;
+  let resolvedLinks = 0;
+  let unresolvedLinks = 0;
 
   for (const page of pages) {
     if (page.links.length > 0) {
@@ -477,13 +505,28 @@ export function summarizeNuclinoLinks(pages: NuclinoPage[]): NuclinoLinkStats {
     totalLinks += page.links.length;
     for (const link of page.links) {
       targetPages.add(link.targetPageId);
+      if (knownPageIds.has(link.targetPageId)) {
+        resolvedLinks++;
+      } else {
+        unresolvedLinks++;
+        const key = link.targetFilename || link.text;
+        unresolvedCounts.set(key, (unresolvedCounts.get(key) ?? 0) + 1);
+      }
     }
   }
+
+  const topUnresolvedTargets = Array.from(unresolvedCounts.entries())
+    .map(([target, count]) => ({ target, count }))
+    .sort((a, b) => b.count - a.count || a.target.localeCompare(b.target))
+    .slice(0, 10);
 
   return {
     totalLinks,
     pagesWithLinks,
     uniqueTargetPages: targetPages.size,
+    resolvedLinks,
+    unresolvedLinks,
+    topUnresolvedTargets,
   };
 }
 

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -150,7 +150,7 @@ export const QUEST_STATUSES = ["lead", "todo", "active", "done", "abandoned"] as
 export type QuestStatus = typeof QUEST_STATUSES[number];
 
 // Import run status (PRD-015A)
-export const IMPORT_RUN_STATUSES = ["completed", "failed", "deleted"] as const;
+export const IMPORT_RUN_STATUSES = ["pending", "completed", "failed", "deleted"] as const;
 export type ImportRunStatus = typeof IMPORT_RUN_STATUSES[number];
 
 // Import visibility options (PRD-015A)
@@ -213,6 +213,8 @@ export const notes = pgTable("notes", {
   contentBlocks: json("content_blocks").$type<ContentBlock[]>(),
   // PRD-004: Quest status field
   questStatus: text("quest_status").$type<QuestStatus>(),
+  // PRD-003 FR-5 (gap F19): set when a session log has been marked reviewed
+  reviewedAt: timestamp("reviewed_at"),
   // PRD-015: Import tracking fields
   sourceSystem: text("source_system"), // e.g., "NUCLINO"
   sourcePageId: text("source_page_id"), // e.g., 8-char hex ID from Nuclino filename
@@ -313,7 +315,7 @@ export const importRuns = pgTable("import_runs", {
   teamId: varchar("team_id").notNull(),
   sourceSystem: text("source_system").notNull(), // e.g., "NUCLINO"
   createdByUserId: varchar("created_by_user_id").notNull(),
-  status: text("status").notNull().$type<ImportRunStatus>().default("completed"),
+  status: text("status").notNull().$type<ImportRunStatus>().default("pending"),
   options: json("options").$type<ImportRunOptions>(),
   stats: json("stats").$type<ImportRunStats>(),
   createdAt: timestamp("created_at").defaultNow(),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "incremental": true,
     "tsBuildInfoFile": "./node_modules/typescript/tsbuildinfo",
     "noEmit": true,
+    "target": "ES2022",
     "module": "ESNext",
     "strict": true,
     "lib": ["esnext", "dom", "dom.iterable"],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     include: ['**/*.test.ts', '**/*.test.tsx', '**/*.spec.ts'],
-    exclude: ['node_modules', 'dist', '.cache'],
+    exclude: ['node_modules', 'dist', '.cache', 'e2e/**'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
## Summary

Gets the note-taking feature set across the finish line in four stages: (1) close the acceptance-criteria gaps in the four open note-taking PRD issues, (2) run a full verified audit of the entire note-taking surface against every PRD (`docs/NOTE_TAKING_GAP_REPORT.md`), (3) implement all P0 + P1 items from that report, and (4) implement all P2 items.

Closes #1, closes #2, closes #3, closes #4, closes #5.

### Stage 4 — P2 (latest)

- **Route unification (P2-3)**: notes list/create/patch/delete + today-session + needs-review handlers live once in `server/notes-handlers.ts` and are registered by BOTH the production and test routers — the prod/test divergence class behind the privacy leak, the sessionDate bug, and the idempotency gap is structurally closed for the notes surface. Update handler uses an explicit field allow-list; quests default to `lead` at creation in production.
- **Offset-based traceability (P2-2, decision)**: backlink clicks scroll to and select the exact mention via stored offsets; content edits re-index outgoing backlinks (snippet refreshed / rebuilt around the title / removed when the mention is gone) via `server/backlink-reindex.ts`. PRD-001/004/005 carry amendments: the block-substrate plan is formally superseded by the offset model; the strict quest transition state machine is deliberately omitted as conflicting with capture-first.
- **Quest status in lists (P2-1)**: colored status badges on quest rows, status filter chips, status in hover previews, reviewed-session checkmarks.
- **Import-run truthfulness (P2-4)**: runs are `pending` until all writes land (`failed` with partial stats on mid-run crash), accurate empty-page stats under partial selection, a View-details dialog in Import Management, and auto-recovery when the AI preview cache expires at Confirm.
- **Session review polish (P2-5)**: Mark-as-Reviewed with `reviewedAt` persistence + list indicator, honest completion math (unlinked matches count as remaining), selection-created entities backlink to their session, and the PRD-mandated review-mode test files now exist.

### Stage 3 — P0/P1 from the done-ness audit
- Privacy enforced server-side (list, needs-review, classification PATCH, idempotent session POST) via shared `server/note-visibility.ts`
- Suggestion persistence keyed to deterministic entity IDs; survives keystrokes and refresh
- AI cache direction-inversion fixed (+ cache version bump); enrichment review dialog mounted; pending AI edges badged, rejected hidden
- Natural-prose quest detection ("asked us to find…") in live detection and quest promotion
- Editable session title + date; entity pages reflect accepted relationships immediately; truthful "Suggestions" vs "AI Cleanup" split (deterministic suggestions ungated); paywall CTA + `/notes/:id` deep links fixed; imported notes render resolved markdown with navigable links; drafts flush on note switch; delete-to-empty removes the session

### Stage 2 — verified audit
`docs/NOTE_TAKING_GAP_REPORT.md`: 93 findings (36 agents, all 25 critical/major claims adversarially verified, zero refuted), per-pillar verdicts, prioritized pick-list. Still open by choice: P3 hygiene, the design-review recommendations, and three unbundled majors (diff-preview filters F57, enrichment undo UI F58, Item/Faction types F59 — recommend descoping).

### Stage 1 — PRD-047–050 completion + branding
Link-with-evidence + Undo, never-blank entity pages, relationship suggestions + quest promotion, Nuclino link evidence, Quest Keeper → Helm branding.

## Test plan
- `npx vitest run` — **710 passing, 35 files** (586 pre-PR): privacy, note-visibility, cache-direction regression, stable-ID + prose detection, title/date editing, draft flush, markdown rendering, enrichment review, backlink re-index, review-mode, session-review page, import-run lifecycle/stats, quest badge/filter tests, and all prior coverage
- `npm run check` — no new TypeScript errors (44 remaining, all in the pre-existing debt files: legacy test fixtures + `server/storage.ts` Drizzle typings)
- Schema note: `notes.reviewed_at` column added; import runs now start `pending` — both take effect on the next `npm run db:push`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ShWCCT15K7dgZLsfFG2w2G